### PR TITLE
Revert new products to use TVector's instead of geo types.

### DIFF
--- a/sbnobj/Common/Reco/CMakeLists.txt
+++ b/sbnobj/Common/Reco/CMakeLists.txt
@@ -1,6 +1,7 @@
 cet_make( 
   LIBRARIES
     cetlib_except
+    ${ROOT_BASIC_LIB_LIST}
   NO_DICTIONARY
   )
 

--- a/sbnobj/Common/Reco/MergedTrackInfo.hh
+++ b/sbnobj/Common/Reco/MergedTrackInfo.hh
@@ -1,15 +1,15 @@
 #ifndef sbncode_MergedTrack_HH
 #define sbncode_MergedTrack_HH
 
-#include "larcoreobj/SimpleTypesAndConstants/geo_vectors.h"
+#include "TVector3.h"
 
 namespace sbn {
   class MergedTrackInfo {
   public:
     // std::array<bool, 3> trunk_wire_direction_is_ascending;
     // std::array<int, 3> branch_wire_start;
-    geo::Point_t vertex;
-    geo::Vector_t direction;
+    TVector3 vertex;
+    TVector3 direction;
     int trunk;
     int branch;
     float branch_overlap;

--- a/sbnobj/Common/Reco/Stub.h
+++ b/sbnobj/Common/Reco/Stub.h
@@ -3,13 +3,13 @@
 
 #include <vector>
 #include "larcoreobj/SimpleTypesAndConstants/geo_types.h"
-#include "larcoreobj/SimpleTypesAndConstants/geo_vectors.h"
+#include "TVector3.h"
 
 namespace sbn {
   class Stub {
   public:
-    geo::Point_t vtx; //!< Interaction Vertex / Start of Stub [cm]
-    geo::Point_t end; //!< End of Stub [cm]
+    TVector3 vtx; //!< Interaction Vertex / Start of Stub [cm]
+    TVector3 end; //!< End of Stub [cm]
     float charge; //!< Total charge of stub, corrected for elec. lifetime [#elec]
     float pitch; //!< Pitch of stub on each wire [cm]
     geo::PlaneID plane; //!< Plane of stub

--- a/sbnobj/Common/Reco/VertexHit.h
+++ b/sbnobj/Common/Reco/VertexHit.h
@@ -3,7 +3,7 @@
 
 #include <vector>
 #include "larcoreobj/SimpleTypesAndConstants/geo_types.h"
-#include "larcoreobj/SimpleTypesAndConstants/geo_vectors.h"
+#include "TVector3.h"
 
 namespace sbn {
   class VertexHit {
@@ -12,7 +12,7 @@ namespace sbn {
     float charge;
     float proj_dist_to_vertex;
     int spID;
-    geo::Point_t spXYZ;
+    TVector3 spXYZ;
     float pitch;
     float dqdx;
     float dedx;

--- a/sbnobj/Common/Reco/classes_def.xml
+++ b/sbnobj/Common/Reco/classes_def.xml
@@ -72,7 +72,8 @@
   <class name="art::Wrapper<art::Assns<float,recob::Shower,void>>" />
   <class name="art::Wrapper<art::Assns<recob::Shower,float,void>>" />
 
-  <class name="sbn::Stub" ClassVersion="10">
+  <class name="sbn::Stub" ClassVersion="11">
+   <version ClassVersion="11" checksum="1552964364"/>
    <version ClassVersion="10" checksum="3948825604"/>
   </class>
   <class name="std::vector<sbn::Stub>" />
@@ -88,7 +89,8 @@
   <class name="art::Assns<sbn::VertexHit, sbn::Stub>" />
   <class name="art::Wrapper<art::Assns<sbn::VertexHit, sbn::Stub>>" />
 
-  <class name="sbn::VertexHit" ClassVersion="10">
+  <class name="sbn::VertexHit" ClassVersion="11">
+   <version ClassVersion="11" checksum="4130374952"/>
    <version ClassVersion="10" checksum="802899277"/>
   </class>
   <class name="std::vector<sbn::VertexHit>" />
@@ -102,7 +104,8 @@
   <class name="art::Assns<recob::Vertex, sbn::VertexHit>" />
   <class name="art::Wrapper<art::Assns<recob::Vertex, sbn::VertexHit>>" />
 
-  <class name="sbn::MergedTrackInfo" ClassVersion="10">
+  <class name="sbn::MergedTrackInfo" ClassVersion="11">
+   <version ClassVersion="11" checksum="72646431"/>
    <version ClassVersion="10" checksum="252455777"/>
   </class>
   <class name="std::vector<sbn::MergedTrackInfo>" />


### PR DESCRIPTION
During the porting to the new repository structure, a bunch of TVector's were apparently changed to geo-types. This breaks a bunch of existing code (including code that was merged into sbncode).

This commit reverts those changes.