### PR TITLE
SBNEventWeight

### DIFF
--- a/sbnobj/Common/CMakeLists.txt
+++ b/sbnobj/Common/CMakeLists.txt
@@ -1,6 +1,6 @@
+add_subdirectory(Analysis)
 add_subdirectory(CRT)
 add_subdirectory(PMT)
 add_subdirectory(Reco)
-add_subdirectory(Analysis)
-
+add_subdirectory(SBNEventWeight)
 

--- a/sbnobj/Common/SBNEventWeight/CMakeLists.txt
+++ b/sbnobj/Common/SBNEventWeight/CMakeLists.txt
@@ -1,0 +1,16 @@
+cet_make( 
+  NO_DICTIONARY
+  LIBRARIES
+    cetlib_except
+    ${ROOT_BASIC_LIB_LIST}
+    ${CLHEP}
+    ${ART_FRAMEWORK_SERVICES_REGISTRY}
+    ${ART_FRAMEWORK_SERVICES_OPTIONAL}
+    ${ART_FRAMEWORK_SERVICES_OPTIONAL_RANDOMNUMBERGENERATOR_SERVICE}
+)
+
+art_dictionary(DICTIONARY_LIBRARIES sbnobj_Common_SBNEventWeight)
+
+install_headers()
+install_source()
+

--- a/sbnobj/Common/SBNEventWeight/EventWeightMap.cc
+++ b/sbnobj/Common/SBNEventWeight/EventWeightMap.cc
@@ -1,0 +1,2 @@
+#include "sbnobj/Common/SBNEventWeight/EventWeightMap.h"
+

--- a/sbnobj/Common/SBNEventWeight/EventWeightMap.h
+++ b/sbnobj/Common/SBNEventWeight/EventWeightMap.h
@@ -1,0 +1,17 @@
+#ifndef _SBN_EVENTWEIGHTMAP_H_
+#define _SBN_EVENTWEIGHTMAP_H_
+
+#include <map>
+#include <vector>
+#include <string>
+
+namespace sbn {
+  namespace evwgh {
+
+typedef std::map<std::string, std::vector<float> > EventWeightMap;
+
+  }  // namespace evwgh
+}  // namespace sbn
+
+#endif  // _SBN_MCEVENTWEIGHT_H_
+

--- a/sbnobj/Common/SBNEventWeight/EventWeightMap.h
+++ b/sbnobj/Common/SBNEventWeight/EventWeightMap.h
@@ -8,10 +8,17 @@
 namespace sbn {
   namespace evwgh {
 
+/**
+ * @typedef EventWeightMap
+ * @brief Container for event-level weights
+ *
+ * Provides a mapping from a string identifier for a particular weight
+ * calculator to the corresponding set of weights for each universe.
+ */
 typedef std::map<std::string, std::vector<float> > EventWeightMap;
 
   }  // namespace evwgh
 }  // namespace sbn
 
-#endif  // _SBN_MCEVENTWEIGHT_H_
+#endif  // _SBN_EVENTWEIGHTMAP_H_
 

--- a/sbnobj/Common/SBNEventWeight/EventWeightParameterSet.cxx
+++ b/sbnobj/Common/SBNEventWeight/EventWeightParameterSet.cxx
@@ -24,7 +24,7 @@ void EventWeightParameterSet::Configure(std::string name, ReweightType rwtype, s
     fNuniverses = 1;
   }
   else {
-    // cet exception here
+    std::cerr << "EventWeightParameterSet: Unknown reweight type " << fRWType << std::endl;
     assert(false);
   }
 }
@@ -35,7 +35,7 @@ void EventWeightParameterSet::Configure(std::string name, std::string rwtype_str
   else if (rwtype_string == "pmNsigma") Configure(name, kPMNSigma);
   else if (rwtype_string == "fixed") Configure(name, kFixed);
   else {
-    // cet exception here, unknown rw type string
+    std::cerr << "EventWeightParameterSet: Unknown reweight type " << rwtype_string << std::endl;
     assert(false);
   }
 }
@@ -50,7 +50,7 @@ void EventWeightParameterSet::AddParameter(
 
 void EventWeightParameterSet::Sample(CLHEP::HepRandomEngine& engine) {
   if (fRWType == kDefault) {
-    // cet exception here, didn't configure
+    std::cerr << "EventWeightParameterSet: Must be configured before sampling." << std::endl;
     assert(false);
   }
 
@@ -76,14 +76,16 @@ void EventWeightParameterSet::Sample(CLHEP::HepRandomEngine& engine) {
       }
 
       else {
-        // cet exception here
+        std::cerr << "EventWeightParameterSet: Unknown reweight type " << fRWType << std::endl;
+        assert(false);
       }
     }
   }
 
   // Multivariate Gaussian sampling
   else {
-
+    std::cerr << "EventWeightParameterSet: Multivariate Gaussian sampling is not implemented." << std::endl;
+    assert(false);
   }
 }
 

--- a/sbnobj/Common/SBNEventWeight/EventWeightParameterSet.cxx
+++ b/sbnobj/Common/SBNEventWeight/EventWeightParameterSet.cxx
@@ -1,0 +1,92 @@
+#include <cassert>
+#include <string>
+#include <map>
+#include <vector>
+#include "TMatrixD.h"
+#include "CLHEP/Random/RandGaussQ.h"
+#include "EventWeightParameterSet.h"
+
+namespace sbn {
+  namespace evwgh {
+
+void EventWeightParameterSet::Configure(std::string name, ReweightType rwtype, size_t nuni) {
+  fName = name;
+  fRWType = rwtype;
+  fNuniverses = nuni;
+
+  if (fRWType == kMultisim) {
+    fNuniverses = nuni;
+  }
+  else if (fRWType == kPMNSigma) {
+    fNuniverses = 2;
+  }
+  else if (fRWType == kFixed) {
+    fNuniverses = 1;
+  }
+  else {
+    // cet exception here
+    assert(false);
+  }
+}
+
+
+void EventWeightParameterSet::Configure(std::string name, std::string rwtype_string, size_t nuni) {
+  if (rwtype_string == "multisim") Configure(name, kMultisim, nuni);
+  else if (rwtype_string == "pmNsigma") Configure(name, kPMNSigma);
+  else if (rwtype_string == "fixed") Configure(name, kFixed);
+  else {
+    // cet exception here, unknown rw type string
+    assert(false);
+  }
+}
+
+
+void EventWeightParameterSet::AddParameter(
+    std::string name, float width, float mean, size_t covIndex) {
+  EventWeightParameter p(name, mean, width, covIndex);
+  fParameterMap.insert({ p, std::vector<float>() });
+}
+
+
+void EventWeightParameterSet::Sample(CLHEP::HepRandomEngine& engine) {
+  if (fRWType == kDefault) {
+    // cet exception here, didn't configure
+    assert(false);
+  }
+
+  // No covariance matrix, uncorrelated sampling
+  if (!fCovarianceMatrix) {
+    for (auto& it : fParameterMap) {
+      const EventWeightParameter& p = it.first;
+
+      if (fRWType == kMultisim) {
+        for (size_t i=0; i<fNuniverses; i++) {
+          float r = CLHEP::RandGaussQ::shoot(&engine, p.fMean, p.fWidth);
+          it.second.push_back(r);
+        }
+      }
+
+      else if (fRWType == kPMNSigma) {
+        it.second.push_back(p.fMean + p.fWidth);
+        it.second.push_back(p.fMean - p.fWidth);
+      }
+
+      else if (fRWType == kFixed) {
+        it.second.push_back(p.fMean + p.fWidth);
+      }
+
+      else {
+        // cet exception here
+      }
+    }
+  }
+
+  // Multivariate Gaussian sampling
+  else {
+
+  }
+}
+
+  }  // namespace evwgh
+}  // namespace sbn
+

--- a/sbnobj/Common/SBNEventWeight/EventWeightParameterSet.h
+++ b/sbnobj/Common/SBNEventWeight/EventWeightParameterSet.h
@@ -1,0 +1,140 @@
+#ifndef _SBN_EVENTWEIGHTPARAMETERSET_H_
+#define _SBN_EVENTWEIGHTPARAMETERSET_H_
+
+#include <string>
+#include <map>
+#include <vector>
+#include "TMatrixD.h"
+
+namespace CLHEP { class HepRandomEngine; }
+
+namespace sbn {
+  namespace evwgh {
+
+/**
+ * @struct EventWeightParameter
+ * @brief A single parameter to be reweighted.
+ */
+struct EventWeightParameter {
+  /** Default constructor. */
+  EventWeightParameter() : fName(""), fMean(0), fWidth(1), fCovIndex(0) {}
+
+  /** Constructor specifying all parameter properties. */
+  EventWeightParameter(std::string name, float mean, float width, size_t covIndex=0)
+      : fName(name), fMean(mean), fWidth(width), fCovIndex(covIndex) {}
+
+  /** Comparison operator (required for use as an std::map key). */
+  inline friend bool operator<(const EventWeightParameter& lhs,
+                               const EventWeightParameter& rhs) {
+    return lhs.fName < rhs.fName;
+  }
+
+  /** Equality operator, testing equality of all members. */
+  inline friend bool operator==(const EventWeightParameter& lhs,
+                                const EventWeightParameter& rhs) {
+    return (lhs.fName == rhs.fName &&
+            lhs.fMean == rhs.fMean &&
+            lhs.fWidth == rhs.fWidth &&
+            lhs.fCovIndex == rhs.fCovIndex);
+  }
+
+  std::string fName;  //!< Parameter name
+  float fMean;  //!< Gaussian mean
+  float fWidth;  //!< Gaussian sigma
+  size_t fCovIndex;  //!< Index in the covariance matrix (if any)
+};
+
+
+/**
+ * @class EventWeightParameterSet
+ * @brief Container for a set of reweightable parameters
+ *
+ * This class performs the random sampling of reweightable parameters
+ * according to user configuration and provides persistence of the sampled
+ * values.
+ */
+class EventWeightParameterSet {
+public:
+  /** The type of random throws to perform. */
+  typedef enum rwtype { kMultisim, kPMNSigma, kFixed, kDefault } ReweightType;
+
+  /** Default constructor. */
+  EventWeightParameterSet() : fCovarianceMatrix(nullptr), fRWType(kDefault) {}
+
+  /** Equality operator, testing equality of all members. */
+  inline friend bool operator==(const EventWeightParameterSet& lhs,
+                                const EventWeightParameterSet& rhs) {
+    return (lhs.fParameterMap == rhs.fParameterMap &&
+            lhs.fCovarianceMatrix == rhs.fCovarianceMatrix &&
+            lhs.fName == rhs.fName &&
+            lhs.fRWType == rhs.fRWType &&
+            lhs.fNuniverses == rhs.fNuniverses);
+  }
+
+  /**
+   * Configure the parameter set.
+   *
+   * @param name Name of the parameter set
+   * @param rwtype Specifies the type of random throws to perform
+   * @param nuni Number of random throws (universes)
+   */
+  void Configure(std::string name, ReweightType rwtype, size_t nuni=1);
+
+  /**
+   * Configure the parameter set with a string reweight type,
+   *
+   * @param name Name of the parameter set
+   * @param rwtype_string Specifies the type of random throws to perform
+   * @param nuni Number of random throws (universes)
+   */
+  void Configure(std::string name, std::string rwtype_string, size_t nuni=1);
+
+  /**
+   * Add a new parameter to the set.
+   *
+   * @param name Name of the parameter
+   * @param width Standard deviation for Gaussian throws
+   * @param mean Optional nonzero mean for Gaussian throws
+   * @param covIndex Optional Index in the (optional) covariance matrix
+   */
+  void AddParameter(std::string name, float width, float mean=0, size_t covIndex=0);
+
+  /**
+   * Specify a covariance matrix for correlated throws.
+   *
+   * Note: use the covIndex argument to AddParameter to specify the index
+   * in the covariance matrix that corresponds to a particular parameter.
+   *
+   * @param cov The covariance matrix
+   */
+  void SetCovarianceMatrix(TMatrixD* cov) { fCovarianceMatrix = cov; }
+
+  /**
+   * Perform the random sampling.
+   *
+   * This function should be called only after the parameter set has been
+   * configured and all parameters have been added. It will perform the
+   * random sampling of all parameters to populate the parameter map
+   * (fParameterMap) which contains the parameter values for universe for
+   * each parameter.
+   *
+   * A random number generator engine is provided here, to enable throws with
+   * different, fixed user-controlled random seeds for each parameter set.
+   *
+   * @param engine The random number generator engine to use for sampling.
+   */
+  void Sample(CLHEP::HepRandomEngine& engine);
+
+public:
+  std::map<EventWeightParameter, std::vector<float> > fParameterMap;  //!< Mapping of parameter names to values
+  TMatrixD* fCovarianceMatrix;  //!< Covariance matrix for correlated throws (optional)
+  std::string fName;  //!< Name of the parameter set
+  ReweightType fRWType;  //!< Type of throws (the same for all parameters in a set)
+  size_t fNuniverses;  //!< Number of universes (random throws)
+};
+
+  }  // namespace evwgh
+}  // namespace sbn
+
+#endif  // _SBN_EVENTWEIGHTPARAMETERSET_H_
+

--- a/sbnobj/Common/SBNEventWeight/EventWeightParameterSet.h
+++ b/sbnobj/Common/SBNEventWeight/EventWeightParameterSet.h
@@ -126,11 +126,11 @@ public:
   void Sample(CLHEP::HepRandomEngine& engine);
 
 public:
-  std::map<EventWeightParameter, std::vector<float> > fParameterMap;  //!< Mapping of parameter names to values
+  std::map<EventWeightParameter, std::vector<float> > fParameterMap;  //!< Mapping of definitions to the set of values
   TMatrixD* fCovarianceMatrix;  //!< Covariance matrix for correlated throws (optional)
   std::string fName;  //!< Name of the parameter set
   ReweightType fRWType;  //!< Type of throws (the same for all parameters in a set)
-  size_t fNuniverses;  //!< Number of universes (random throws)
+  size_t fNuniverses;  //!< Number of universes (i.e. random throws)
 };
 
   }  // namespace evwgh

--- a/sbnobj/Common/SBNEventWeight/classes.h
+++ b/sbnobj/Common/SBNEventWeight/classes.h
@@ -1,0 +1,9 @@
+#include <map>
+#include <string>
+#include <vector>
+#include "canvas/Persistency/Common/Wrapper.h"
+#include "canvas/Persistency/Common/Assns.h"
+#include "sbnobj/Common/SBNEventWeight/EventWeightMap.h"
+#include "sbnobj/Common/SBNEventWeight/EventWeightParameterSet.h"
+#include "nusimdata/SimulationBase/MCTruth.h"
+

--- a/sbnobj/Common/SBNEventWeight/classes_def.xml
+++ b/sbnobj/Common/SBNEventWeight/classes_def.xml
@@ -1,0 +1,26 @@
+<lcgdict>
+  <class name="sbn::evwgh::EventWeightMap"/>
+  <class name="art::Wrapper<sbn::evwgh::EventWeightMap>"/>
+  <class name="std::vector<sbn::evwgh::EventWeightMap>"/>
+  <class name="art::Wrapper<std::vector<sbn::evwgh::EventWeightMap> >"/>
+
+  <class name="sbn::evwgh::EventWeightParameter"/>
+  <class name="art::Wrapper<sbn::evwgh::EventWeightParameter>"/>
+  <class name="map<sbn::evwgh::EventWeightParameter,vector<float> >"/>
+  <class name="art::Wrapper<map<sbn::evwgh::EventWeightParameter,vector<float> > >"/>
+
+  <class name="sbn::evwgh::EventWeightParameterSet"/>
+  <class name="art::Wrapper<sbn::evwgh::EventWeightParameterSet>"/>
+  <class name="vector<sbn::evwgh::EventWeightParameterSet>"/>
+  <class name="art::Wrapper<vector<sbn::evwgh::EventWeightParameterSet> >"/>
+  <enum name="sbn::evwgh::EventWeightParameterSet::ReweightType"/>
+  <enum name="art::Wrapper<sbn::evwgh::EventWeightParameterSet::ReweightType>"/>
+
+  <class name="art::Assns<simb::MCTruth,sbn::evwgh::EventWeightParameterSet,void>"/>
+  <class name="art::Wrapper<art::Assns<simb::MCTruth,sbn::evwgh::EventWeightParameterSet,void> >"/>
+  <class name="art::Assns<map<string,vector<float> >,simb::MCTruth,void>"/>
+  <class name="art::Assns<simb::MCTruth,map<string,vector<float> >,void>"/>
+  <class name="art::Wrapper<art::Assns<map<string,vector<float> >,simb::MCTruth,void> >"/>
+  <class name="art::Wrapper<art::Assns<simb::MCTruth,map<string,vector<float> >,void> >"/>
+</lcgdict>
+

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -2,7 +2,7 @@
 
 # The *parent* line must the first non-commented line and defines this product and version
 # The version should be of the form vxx_yy_zz (e.g. v01_02_03)
-parent sbnobj v09_11_02
+parent sbnobj v09_11_03
 defaultqual e19
 
 # These optional lines define the installed directories where headers,


### PR DESCRIPTION
This pull request adds data products for SBN event weights (stored on the `art::Event`s) and parameters (stored on the `art::Run`s). The classes are located in a new directory `Common/SBNEventWeight`.

The former (weights) are simply a `typedef`, while the latter (parameters) are a new class. That class stores data in public members using only basic and STL types. Member functions related to initialization do have nontrivial logic and have library (CLHEP) dependencies, and currently handle error conditions with `assert` to avoid any LArSoft (specifically `cetlib`) dependence. The initialization code can be relocated to e.g. `sbncode` if preferred.

This should be reviewed alongside the `sbndcode` Pull Request which contains the framework and calculator code: https://github.com/SBNSoftware/sbncode/pull/97