### PR TITLE
Feature/jzettleNewFMObject

### DIFF
--- a/sbnobj/Common/Reco/SimpleFlashMatchVars.cc
+++ b/sbnobj/Common/Reco/SimpleFlashMatchVars.cc
@@ -1,0 +1,1 @@
+#include "sbnobj/Common/Reco/SimpleFlashMatchVars.h"

--- a/sbnobj/Common/Reco/SimpleFlashMatchVars.h
+++ b/sbnobj/Common/Reco/SimpleFlashMatchVars.h
@@ -9,14 +9,16 @@ namespace sbn
   {
   public:
   SimpleFlashMatch(
-    bool present = false, double time = -1, double pe = -1,
+    bool present = false, double time = -1,
+    double charge_q = -1, double light_pe = -1,
     double score = -1, double scr_y = -1, double scr_z = -1,
     double scr_rr = -1, double scr_ratio = -1,
     TVector3 chargeXYZ = TVector3(-999, -999, -999),
     TVector3 lightXYZ = TVector3(-999,-999,-999)):
     mPresent(present),
     mTime(time),
-    mPE(pe),
+    mChargeQ(charge_q),
+    mLightPE(light_pe),
     mScore(score),
     mScr_y(scr_y),
     mScr_z(scr_z),
@@ -28,7 +30,8 @@ namespace sbn
 
     bool mPresent;
     double mTime;
-    double mPE;
+    double mChargeQ;
+    double mLightPE;
     double mScore;
     double mScr_y;
     double mScr_z;

--- a/sbnobj/Common/Reco/SimpleFlashMatchVars.h
+++ b/sbnobj/Common/Reco/SimpleFlashMatchVars.h
@@ -1,0 +1,37 @@
+#ifndef sbncode_Simpleflashmatchvars_H
+#define sbncode_Simpleflashmatchvars_H
+
+#include "TVector3.h"
+
+namespace sbn 
+{
+  class SimpleFlashMatch 
+  {
+  public:
+  SimpleFlashMatch(bool present = false, double time = -1, double score = -1, double scr_y = -1, double scr_z = -1, double scr_rr = -1, double scr_ratio = -1, double pe = -1, TVector3 chargeXYZ = TVector3(-999, -999, -999), TVector3 lightXYZ = TVector3(-999,-999,-999)):
+    mPresent(present),
+    mTime(time),
+    mScore(score),
+    mScr_y(scr_y),
+    mScr_z(scr_z),
+    mScr_rr(scr_rr),
+    mScr_ratio(scr_ratio),
+    mPE(pe),
+    mChargeXYZ(chargeXYZ),
+    mLightXYZ(lightXYZ)
+    {}
+    
+    bool mPresent;
+    double mTime;
+    double mScore;
+    double mScr_y;
+    double mScr_z;
+    double mScr_rr;
+    double mScr_ratio;
+    double mPE;
+    TVector3 mChargeXYZ;
+    TVector3 mLightXYZ;
+  }; //end sbn::SimpleFlashMatch
+}
+
+#endif

--- a/sbnobj/Common/Reco/SimpleFlashMatchVars.h
+++ b/sbnobj/Common/Reco/SimpleFlashMatchVars.h
@@ -8,37 +8,54 @@ namespace sbn
   class SimpleFlashMatch
   {
   public:
-  SimpleFlashMatch(
-    bool present = false, double time = -1,
-    double charge_q = -1, double light_pe = -1,
-    double score = -1, double scr_y = -1, double scr_z = -1,
-    double scr_rr = -1, double scr_ratio = -1,
-    TVector3 chargeXYZ = TVector3(-999, -999, -999),
-    TVector3 lightXYZ = TVector3(-999,-999,-999)):
-    mPresent(present),
-    mTime(time),
-    mChargeQ(charge_q),
-    mLightPE(light_pe),
-    mScore(score),
-    mScr_y(scr_y),
-    mScr_z(scr_z),
-    mScr_rr(scr_rr),
-    mScr_ratio(scr_ratio),
-    mChargeXYZ(chargeXYZ),
-    mLightXYZ(lightXYZ)
-    {}
+    struct Charge {
+      double q;        //!< charge in slc
+      TVector3 center; //!< Weighted center position [cm]
+      Charge(double q_ = -1., TVector3 center_ = TVector3(-999, -999, -999)) :
+        q(q_), center(center_)
+        {}
+    };
+    struct Flash {
+      double pe;       //!< photo-electrons on flash
+      TVector3 center; //!< Weighted center position [cm]
+      Flash(double pe_ = -1., TVector3 center_ = TVector3(-999, -999, -999)) :
+        pe(pe_), center(center_)
+        {}
+    };
+    struct Score {
+      double total; //!< total score, sum of terms
+      double y;     //!< score for y metric
+      double z;     //!< score for z metric
+      double rr;    //!< score for rr metric
+      double ratio; //!< score for ratio metric
+      Score (
+        double total_ = -1.,
+        double y_ = -1., double z_ = -1.,
+        double rr_ = -1., double ratio_ = -1.) :
+        total(total_), y(y_), z(z_), rr(rr_), ratio(ratio_)
+        {}
+      Score (int no_score) : // for no match fill all with the code
+        total(no_score), y(no_score), z(no_score), rr(no_score), ratio(no_score)
+        {}
+    };
 
-    bool mPresent;
-    double mTime;
-    double mChargeQ;
-    double mLightPE;
-    double mScore;
-    double mScr_y;
-    double mScr_z;
-    double mScr_rr;
-    double mScr_ratio;
-    TVector3 mChargeXYZ;
-    TVector3 mLightXYZ;
+    SimpleFlashMatch(
+      bool present_ = false, double time_ = -1,
+      Charge charge_ = Charge(),
+      Flash flash_ = Flash(),
+      Score score_ = Score()):
+      present(present_),
+      time(time_),
+      charge(charge_),
+      light(flash_),
+      score(score_)
+      {}
+
+    bool   present;     //!< Whether there's a match
+    double time;        //!< time of flash
+    Charge charge;      //!< object that contains charge and its position
+    Flash  light;       //!< object that contains flash pe and its position
+    Score  score;       //!< overall and partial scores to the match
   }; //end sbn::SimpleFlashMatch
 }
 

--- a/sbnobj/Common/Reco/SimpleFlashMatchVars.h
+++ b/sbnobj/Common/Reco/SimpleFlashMatchVars.h
@@ -8,7 +8,8 @@ namespace sbn
   class SimpleFlashMatch 
   {
   public:
-  SimpleFlashMatch(bool present = false, double time = -1, double score = -1, double scr_y = -1, double scr_z = -1, double scr_rr = -1, double scr_ratio = -1, double pe = -1, TVector3 chargeXYZ = TVector3(-999, -999, -999), TVector3 lightXYZ = TVector3(-999,-999,-999)):
+
+  SimpleFlashMatch(bool present = false, double time = -1, double score = -1, double scr_y = -1, double scr_z = -1, double scr_rr = -1, double scr_ratio = -1, double pe = -1, TVector3 chargeXYZ = TVector3(-999,-999,-999), TVector3 lightXYZ = TVector3(-999,-999,-999)):
     mPresent(present),
     mTime(time),
     mScore(score),

--- a/sbnobj/Common/Reco/SimpleFlashMatchVars.h
+++ b/sbnobj/Common/Reco/SimpleFlashMatchVars.h
@@ -3,33 +3,37 @@
 
 #include "TVector3.h"
 
-namespace sbn 
+namespace sbn
 {
-  class SimpleFlashMatch 
+  class SimpleFlashMatch
   {
   public:
-
-  SimpleFlashMatch(bool present = false, double time = -1, double score = -1, double scr_y = -1, double scr_z = -1, double scr_rr = -1, double scr_ratio = -1, double pe = -1, TVector3 chargeXYZ = TVector3(-999,-999,-999), TVector3 lightXYZ = TVector3(-999,-999,-999)):
+  SimpleFlashMatch(
+    bool present = false, double time = -1, double pe = -1,
+    double score = -1, double scr_y = -1, double scr_z = -1,
+    double scr_rr = -1, double scr_ratio = -1,
+    TVector3 chargeXYZ = TVector3(-999, -999, -999),
+    TVector3 lightXYZ = TVector3(-999,-999,-999)):
     mPresent(present),
     mTime(time),
+    mPE(pe),
     mScore(score),
     mScr_y(scr_y),
     mScr_z(scr_z),
     mScr_rr(scr_rr),
     mScr_ratio(scr_ratio),
-    mPE(pe),
     mChargeXYZ(chargeXYZ),
     mLightXYZ(lightXYZ)
     {}
-    
+
     bool mPresent;
     double mTime;
+    double mPE;
     double mScore;
     double mScr_y;
     double mScr_z;
     double mScr_rr;
     double mScr_ratio;
-    double mPE;
     TVector3 mChargeXYZ;
     TVector3 mLightXYZ;
   }; //end sbn::SimpleFlashMatch

--- a/sbnobj/Common/Reco/classes.h
+++ b/sbnobj/Common/Reco/classes.h
@@ -8,15 +8,14 @@
 #include "lardataobj/RecoBase/Hit.h"
 #include "lardataobj/RecoBase/Vertex.h"
 
+#include "sbnobj/Common/CRT/CRTHit.hh"
+#include "sbnobj/Common/Reco/FlashTriggerPrimitive.hh"
+#include "sbnobj/Common/Reco/MergedTrackInfo.hh"
 #include "sbnobj/Common/Reco/RangeP.h"
 #include "sbnobj/Common/Reco/ShowerSelectionVars.h"
 #include "sbnobj/Common/Reco/SimpleFlashMatchVars.h"
-#include "sbnobj/Common/Reco/FlashTriggerPrimitive.hh"
-#include "sbnobj/Common/CRT/CRTHit.hh"
-
-#include "sbnobj/Common/Reco/MergedTrackInfo.hh"
-#include "sbnobj/Common/Reco/VertexHit.h"
 #include "sbnobj/Common/Reco/Stub.h"
+#include "sbnobj/Common/Reco/VertexHit.h"
 
 #include <vector>
 #include <utility>

--- a/sbnobj/Common/Reco/classes.h
+++ b/sbnobj/Common/Reco/classes.h
@@ -10,6 +10,7 @@
 
 #include "sbnobj/Common/Reco/RangeP.h"
 #include "sbnobj/Common/Reco/ShowerSelectionVars.h"
+#include "sbnobj/Common/Reco/SimpleFlashMatchVars.h"
 #include "sbnobj/Common/Reco/FlashTriggerPrimitive.hh"
 #include "sbnobj/Common/CRT/CRTHit.hh"
 

--- a/sbnobj/Common/Reco/classes_def.xml
+++ b/sbnobj/Common/Reco/classes_def.xml
@@ -32,7 +32,7 @@
   <class name="art::Wrapper<std::vector<sbn::FlashTriggerPrimitive>>" />
 
   <class name="sbn::SimpleFlashMatch" ClassVersion="11">
-   <version ClassVersion="11" checksum="52074626"/>
+   <version ClassVersion="11" checksum="27328003"/>
   </class>
   <class name="sbn::SimpleFlashMatch::Charge" ClassVersion="11">
    <version ClassVersion="11" checksum="4057441913"/>

--- a/sbnobj/Common/Reco/classes_def.xml
+++ b/sbnobj/Common/Reco/classes_def.xml
@@ -31,6 +31,13 @@
   <class name="std::vector<sbn::FlashTriggerPrimitive>" />
   <class name="art::Wrapper<std::vector<sbn::FlashTriggerPrimitive>>" />
 
+  <class name="sbn::SimpleFlashMatch" />
+  <class name="std::vector<sbn::SimpleFlashMatch>" />
+  <class name="art::Wrapper<sbn::SimpleFlashMatch>" />
+  <class name="art::Wrapper<std::vector<sbn::SimpleFlashMatch>>" />   
+  <class name="art::Assns<recob::PFParticle, sbn::SimpleFlashMatch>" />
+  <class name="art::Wrapper<art::Assns<recob::PFParticle, sbn::SimpleFlashMatch>>" />
+
   <class name="art::Assns<recob::Track, sbn::crt::CRTHit, anab::T0>" />
   <class name="art::Wrapper<art::Assns<recob::Track, sbn::crt::CRTHit, anab::T0>>" />
   <class name="art::Assns<recob::Track, sbn::crt::CRTHit, void>" />

--- a/sbnobj/Common/Reco/classes_def.xml
+++ b/sbnobj/Common/Reco/classes_def.xml
@@ -31,12 +31,16 @@
   <class name="std::vector<sbn::FlashTriggerPrimitive>" />
   <class name="art::Wrapper<std::vector<sbn::FlashTriggerPrimitive>>" />
 
-  <class name="sbn::SimpleFlashMatch" />
+  <class name="sbn::SimpleFlashMatch" ClassVersion="11">
+   <version ClassVersion="11" checksum="1835473918"/>
+  </class>
   <class name="std::vector<sbn::SimpleFlashMatch>" />
   <class name="art::Wrapper<sbn::SimpleFlashMatch>" />
   <class name="art::Wrapper<std::vector<sbn::SimpleFlashMatch>>" />   
-  <class name="art::Assns<recob::PFParticle, sbn::SimpleFlashMatch>" />
-  <class name="art::Wrapper<art::Assns<recob::PFParticle, sbn::SimpleFlashMatch>>" />
+  <class name="art::Assns<recob::PFParticle, sbn::SimpleFlashMatch, void>" />
+  <class name="art::Wrapper<art::Assns<recob::PFParticle, sbn::SimpleFlashMatch, void>>" />
+  <class name="art::Assns<sbn::SimpleFlashMatch,recob::PFParticle,void>" />
+  <class name="art::Wrapper<art::Assns<sbn::SimpleFlashMatch,recob::PFParticle,void> >" />
 
   <class name="art::Assns<recob::Track, sbn::crt::CRTHit, anab::T0>" />
   <class name="art::Wrapper<art::Assns<recob::Track, sbn::crt::CRTHit, anab::T0>>" />

--- a/sbnobj/Common/Reco/classes_def.xml
+++ b/sbnobj/Common/Reco/classes_def.xml
@@ -32,8 +32,16 @@
   <class name="art::Wrapper<std::vector<sbn::FlashTriggerPrimitive>>" />
 
   <class name="sbn::SimpleFlashMatch" ClassVersion="11">
-   <version ClassVersion="11" checksum="1776089531"/>
-   <version ClassVersion="10" checksum="1835473918"/>
+   <version ClassVersion="11" checksum="52074626"/>
+  </class>
+  <class name="sbn::SimpleFlashMatch::Charge" ClassVersion="11">
+   <version ClassVersion="11" checksum="4057441913"/>
+  </class>
+  <class name="sbn::SimpleFlashMatch::Flash" ClassVersion="11">
+   <version ClassVersion="11" checksum="3396465673"/>
+  </class>
+  <class name="sbn::SimpleFlashMatch::Score" ClassVersion="11">
+   <version ClassVersion="11" checksum="3697420401"/>
   </class>
   <class name="std::vector<sbn::SimpleFlashMatch>" />
   <class name="art::Wrapper<sbn::SimpleFlashMatch>" />

--- a/sbnobj/Common/Reco/classes_def.xml
+++ b/sbnobj/Common/Reco/classes_def.xml
@@ -32,15 +32,16 @@
   <class name="art::Wrapper<std::vector<sbn::FlashTriggerPrimitive>>" />
 
   <class name="sbn::SimpleFlashMatch" ClassVersion="11">
-   <version ClassVersion="11" checksum="1835473918"/>
+   <version ClassVersion="11" checksum="3301528932"/>
+   <version ClassVersion="10" checksum="1835473918"/>
   </class>
   <class name="std::vector<sbn::SimpleFlashMatch>" />
   <class name="art::Wrapper<sbn::SimpleFlashMatch>" />
-  <class name="art::Wrapper<std::vector<sbn::SimpleFlashMatch>>" />   
-  <class name="art::Assns<recob::PFParticle, sbn::SimpleFlashMatch, void>" />
-  <class name="art::Wrapper<art::Assns<recob::PFParticle, sbn::SimpleFlashMatch, void>>" />
-  <class name="art::Assns<sbn::SimpleFlashMatch,recob::PFParticle,void>" />
-  <class name="art::Wrapper<art::Assns<sbn::SimpleFlashMatch,recob::PFParticle,void> >" />
+  <class name="art::Wrapper<std::vector<sbn::SimpleFlashMatch>>" />
+  <class name="art::Assns<recob::PFParticle, sbn::SimpleFlashMatch>" />
+  <class name="art::Wrapper<art::Assns<recob::PFParticle, sbn::SimpleFlashMatch>>" />
+  <class name="art::Assns<sbn::SimpleFlashMatch,recob::PFParticle, void>" />
+  <class name="art::Wrapper<art::Assns<sbn::SimpleFlashMatch, recob::PFParticle, void> >" />
 
   <class name="art::Assns<recob::Track, sbn::crt::CRTHit, anab::T0>" />
   <class name="art::Wrapper<art::Assns<recob::Track, sbn::crt::CRTHit, anab::T0>>" />

--- a/sbnobj/Common/Reco/classes_def.xml
+++ b/sbnobj/Common/Reco/classes_def.xml
@@ -32,7 +32,7 @@
   <class name="art::Wrapper<std::vector<sbn::FlashTriggerPrimitive>>" />
 
   <class name="sbn::SimpleFlashMatch" ClassVersion="11">
-   <version ClassVersion="11" checksum="3301528932"/>
+   <version ClassVersion="11" checksum="1776089531"/>
    <version ClassVersion="10" checksum="1835473918"/>
   </class>
   <class name="std::vector<sbn::SimpleFlashMatch>" />


### PR DESCRIPTION
Pull request for the addition of a new sbn::SimpleFlashMatch data product replacing the anab::T0 object that was used previously. This is largely done to improve the amount of stored information from the simple flash match object in the CAF files. Tested on SBND and ICARUS simulations and shown to fill the correct object in the CAF files.