### PR TITLE
Updates to Stub Objects for Space Charge

### DIFF
--- a/sbnobj/Common/Reco/Stub.h
+++ b/sbnobj/Common/Reco/Stub.h
@@ -18,6 +18,9 @@ namespace sbn {
     TVector3 vtx; //!< Interaction Vertex / Start of Stub [cm]
     TVector3 end; //!< End of Stub [cm]
 
+    float efield_end; //!< The E-Field at the stub end point
+    float efield_vtx; //!< The E-Field at the reconstructed vertex
+
     // Per-plane information: sorted so that the "best" plane is the first index
     std::vector<geo::PlaneID> plane; //!< The plane ID
 

--- a/sbnobj/Common/Reco/Stub.h
+++ b/sbnobj/Common/Reco/Stub.h
@@ -3,7 +3,7 @@
 
 #include <vector>
 #include "larcoreobj/SimpleTypesAndConstants/geo_types.h"
-#include "TVector3.h"
+#include "larcoreobj/SimpleTypesAndConstants/geo_vectors.h"
 
 namespace sbn {
   class StubHit {
@@ -15,8 +15,8 @@ namespace sbn {
 
   class Stub {
   public:
-    TVector3 vtx; //!< Interaction Vertex / Start of Stub [cm]
-    TVector3 end; //!< End of Stub [cm]
+    geo::Point_t vtx; //!< Interaction Vertex / Start of Stub. Space charge corrected. [cm]
+    geo::Point_t end; //!< End of Stub. Space charge corrected. [cm]
 
     float efield_end; //!< The E-Field at the stub end point
     float efield_vtx; //!< The E-Field at the reconstructed vertex

--- a/sbnobj/Common/Reco/VertexHit.h
+++ b/sbnobj/Common/Reco/VertexHit.h
@@ -3,7 +3,7 @@
 
 #include <vector>
 #include "larcoreobj/SimpleTypesAndConstants/geo_types.h"
-#include "TVector3.h"
+#include "larcoreobj/SimpleTypesAndConstants/geo_vectors.h"
 
 namespace sbn {
   class VertexHit {
@@ -11,16 +11,14 @@ namespace sbn {
     geo::WireID wire; //!< Wire the the hit is on
     float charge; //!< Calibrated and lifetime-corrected charge on the hit [#elec]
     float proj_dist_to_vertex; //!< Distnace from the hit to the vertex on the wireplane
-    float vtxw; //!< Wire of the vertex associated with this hit
+    float vtxw; //!< Wire of the vertex associated with this hit.
+    float vtxx; //!< X-Position of the vertex associated with this hit as seen by wire-planes.
     int spID; //!< ID of the SpacePoint associated with this hit
-    TVector3 spXYZ; //!< 3D location of the SpacePoint associated with this hit
-    float pitch; //!< Computed pitch of a track traversing from the vertex to this hit [cm]
+    geo::Point_t spXYZ; //!< 3D location of the SpacePoint associated with this hit. Space charge corrected. [cm]
+    geo::Point_t vtxXYZ; //!< 3D location of the Vertex associated with this hit. Space charge corrected. [cm]
+    float pitch; //!< Computed pitch of a track traversing from the vertex to this hit. Space charge corrected. [cm]
     float dqdx; //!< charge/pitch [#elec/cm]
     float dedx; //!< Recombination corrected dQ/dx [MeV/cm]
-    std::vector<int> nearbyPFPIDs; //!< ID's of PFParticle's near this hit in 2D
-    std::vector<float> nearbyPFPDists; //!< 2D Dot product of vertex-hit direction to PFParticle direction
-    std::vector<float> nearbyPFP3DDists; //!< ID's of PFPArticle's near this hit in 3D
-    std::vector<int> nearbyPFP3DIDs; //!< 3D Dot product of vertex-hit direction to PFParticle direction
   };
 } // end namespace sbn
 

--- a/sbnobj/Common/Reco/VertexHit.h
+++ b/sbnobj/Common/Reco/VertexHit.h
@@ -8,11 +8,11 @@
 namespace sbn {
   class VertexHit {
   public:
-    geo::WireID wire; //!< Wire the the hit is on
+    geo::WireID wire; //!< Wire that the hit is on
     float charge; //!< Calibrated and lifetime-corrected charge on the hit [#elec]
     float proj_dist_to_vertex; //!< Distnace from the hit to the vertex on the wireplane
-    float vtxw; //!< Wire of the vertex associated with this hit.
-    float vtxx; //!< X-Position of the vertex associated with this hit as seen by wire-planes.
+    float vtxw; //!< Wire of the vertex associated with this hit. Not space charge corrected. [cm]
+    float vtxx; //!< X-Position of the vertex associated with this hit as seen by wire-planes. Not space charge corrected. [cm]
     int spID; //!< ID of the SpacePoint associated with this hit
     geo::Point_t spXYZ; //!< 3D location of the SpacePoint associated with this hit. Space charge corrected. [cm]
     geo::Point_t vtxXYZ; //!< 3D location of the Vertex associated with this hit. Space charge corrected. [cm]

--- a/sbnobj/Common/Reco/classes_def.xml
+++ b/sbnobj/Common/Reco/classes_def.xml
@@ -72,7 +72,8 @@
   <class name="art::Wrapper<art::Assns<float,recob::Shower,void>>" />
   <class name="art::Wrapper<art::Assns<recob::Shower,float,void>>" />
 
-  <class name="sbn::Stub" ClassVersion="13">
+  <class name="sbn::Stub" ClassVersion="14">
+   <version ClassVersion="14" checksum="3533111376"/>
    <version ClassVersion="13" checksum="3160890792"/>
    <version ClassVersion="12" checksum="1338933861"/>
    <version ClassVersion="11" checksum="1552964364"/>
@@ -96,7 +97,8 @@
   <class name="art::Assns<sbn::VertexHit, sbn::Stub>" />
   <class name="art::Wrapper<art::Assns<sbn::VertexHit, sbn::Stub>>" />
 
-  <class name="sbn::VertexHit" ClassVersion="12">
+  <class name="sbn::VertexHit" ClassVersion="13">
+   <version ClassVersion="13" checksum="4209046416"/>
    <version ClassVersion="12" checksum="1155278781"/>
    <version ClassVersion="11" checksum="4130374952"/>
    <version ClassVersion="10" checksum="802899277"/>

--- a/sbnobj/Common/Reco/classes_def.xml
+++ b/sbnobj/Common/Reco/classes_def.xml
@@ -72,7 +72,8 @@
   <class name="art::Wrapper<art::Assns<float,recob::Shower,void>>" />
   <class name="art::Wrapper<art::Assns<recob::Shower,float,void>>" />
 
-  <class name="sbn::Stub" ClassVersion="12">
+  <class name="sbn::Stub" ClassVersion="13">
+   <version ClassVersion="13" checksum="3160890792"/>
    <version ClassVersion="12" checksum="1338933861"/>
    <version ClassVersion="11" checksum="1552964364"/>
    <version ClassVersion="10" checksum="3948825604"/>

--- a/sbnobj/Common/Reco/classes_def.xml
+++ b/sbnobj/Common/Reco/classes_def.xml
@@ -72,9 +72,8 @@
   <class name="art::Wrapper<art::Assns<float,recob::Shower,void>>" />
   <class name="art::Wrapper<art::Assns<recob::Shower,float,void>>" />
 
-  <class name="sbn::Stub" ClassVersion="14">
-   <version ClassVersion="14" checksum="3533111376"/>
-   <version ClassVersion="13" checksum="3160890792"/>
+  <class name="sbn::Stub" ClassVersion="13">
+   <version ClassVersion="13" checksum="3533111376"/>
    <version ClassVersion="12" checksum="1338933861"/>
    <version ClassVersion="11" checksum="1552964364"/>
    <version ClassVersion="10" checksum="3948825604"/>


### PR DESCRIPTION
Cleans up stub objects (removes TVector's and other unused variables) and adds in information necessary to incorporate changes for Space Charge.