### PR TITLE
Fix to Missing FileEntry for sbnobj/Common/Calibration/TrackCaloSkimmerObj.h

### DIFF
--- a/sbnobj/Common/Calibration/CMakeLists.txt
+++ b/sbnobj/Common/Calibration/CMakeLists.txt
@@ -1,1 +1,4 @@
 art_dictionary()
+
+install_source()
+install_headers()


### PR DESCRIPTION
_Edit: moved the explanation into an issue ticket (#24) for ease of lookup._

The header in this directory, `sbnobj/Common/Calibration/TrackCaloSkimmerObj.h`, was not installed.
This prevents on-the-fly compilation by ROOT, and therefore loading files with this data object.

While I have tested the fix itself, **this is a GitHub commit, which has not been tested _at all_.** Integration test should tell.