### PR TITLE
Removed empty constructor from `CRTData`

### DIFF
--- a/sbnobj/ICARUS/CRT/CRTData.hh
+++ b/sbnobj/ICARUS/CRT/CRTData.hh
@@ -7,11 +7,11 @@ namespace icarus::crt {
 
   struct CRTData {
 
-      uint8_t  fMac5;    //FEB address following numbering convention common for both data and MC
-      uint32_t fEntry;   //hit index for given FEB in an event (starts from 0 for each event)
-      uint64_t fTs0;     //Absolute hit timestamp [ns]
-      uint64_t fTs1;     //Trigger time, not well defined as of Apr 14, 2021
-      uint16_t fAdc[64]; //ADC readout for each channel. CAEN (Bern) CRT FEBs use only indices 0-31
+      uint8_t  fMac5    { 0 }; ///< FEB address following numbering convention common for both data and MC.
+      uint32_t fEntry;         ///< Hit index for given FEB in an event (starts from 0 for each event).
+      uint64_t fTs0     { 0 }; ///< Absolute hit timestamp [ns]
+      uint64_t fTs1     { 0 }; ///< Trigger time, not well defined as of Apr 14, 2021.
+      uint16_t fAdc[64] {};    ///< ADC readout for each channel. CAEN (Bern) CRT FEBs use only indices 0-31.
       
   };
 

--- a/sbnobj/ICARUS/CRT/CRTData.hh
+++ b/sbnobj/ICARUS/CRT/CRTData.hh
@@ -12,8 +12,7 @@ namespace icarus::crt {
       uint64_t fTs0;     //Absolute hit timestamp [ns]
       uint64_t fTs1;     //Trigger time, not well defined as of Apr 14, 2021
       uint16_t fAdc[64]; //ADC readout for each channel. CAEN (Bern) CRT FEBs use only indices 0-31
-
-      CRTData() {}
+      
   };
 
 } // namespace icarus::crt


### PR DESCRIPTION
What harm could an empty constructor (`CRTData() {}`) ever do?

This is one: it prevents the initialisation of simple data types during construction.
In this case, `CRTData` is a simple plain-old-data structure with integers and an array. A default initialisation sets all the integers _and the elements of the array_ to a default value (`0`). If this does not happen, the simple data type variables are _not initialised_ at all.
Depending on the context, one way or the other may be desired. The only reason to choose the latter is probably just performance, but setting memory to `0` is usually decently fast so it's often not a concern.
In the case of this data structure, it often happens that part of the data is not filled (not all FEB have 64 channels). In this case I argue that the most convenient approach is to have the ADC data initialised to `0`, which is the convention used for unused channels.
Removing the empty constructor and allowing the compiler to generate the default one achieves the purpose (as it would to declare the constructor as `CRTData() = default;`).

It is even better though to initialize the data members explicitly, so that the intention is positively expressed in the code.
This pull request does both (except for one data member where there is no specific convention that I know of — it will be initialised to `0`).
