### PR TITLE
Feature/jskim genie weight module sbn2021 c

### DIFF
--- a/sbnobj/Common/SBNEventWeight/EventWeightParameterSet.h
+++ b/sbnobj/Common/SBNEventWeight/EventWeightParameterSet.h
@@ -60,7 +60,15 @@ struct EventWeightParameter {
 class EventWeightParameterSet {
 public:
   /** The type of random throws to perform. */
-  typedef enum rwtype { kMultisim, kPMNSigma, kMultisigma, kFixed, kDefault } ReweightType;
+  //==== ReweightType_t in sbnanaobj/StandardRecord/SREnums.h should be synchronized to this
+  typedef enum rwtype
+  {
+    kDefault = -1,
+    kMultisim = 0,
+    kPMNSigma = 1,
+    kFixed = 2,
+    kMultisigma = 3,
+  } ReweightType;
 
   /** Default constructor. */
   EventWeightParameterSet() : fCovarianceMatrix(nullptr), fRWType(kDefault) {}

--- a/sbnobj/Common/SBNEventWeight/EventWeightParameterSet.h
+++ b/sbnobj/Common/SBNEventWeight/EventWeightParameterSet.h
@@ -23,6 +23,9 @@ struct EventWeightParameter {
   EventWeightParameter(std::string name, float mean, float width, size_t covIndex=0)
       : fName(name), fMean(mean), fWidth(width), fCovIndex(covIndex) {}
 
+  EventWeightParameter(std::string name, float mean, std::vector<float> widths, size_t covIndex=0)
+      : fName(name), fMean(mean), fCovIndex(covIndex), fWidths(widths) {}
+
   /** Comparison operator (required for use as an std::map key). */
   inline friend bool operator<(const EventWeightParameter& lhs,
                                const EventWeightParameter& rhs) {
@@ -42,6 +45,7 @@ struct EventWeightParameter {
   float fMean;  //!< Gaussian mean
   float fWidth;  //!< Gaussian sigma
   size_t fCovIndex;  //!< Index in the covariance matrix (if any)
+  std::vector<float> fWidths; //!< for multi sigma modes
 };
 
 
@@ -56,7 +60,7 @@ struct EventWeightParameter {
 class EventWeightParameterSet {
 public:
   /** The type of random throws to perform. */
-  typedef enum rwtype { kMultisim, kPMNSigma, kFixed, kDefault } ReweightType;
+  typedef enum rwtype { kMultisim, kPMNSigma, kMultisigma, kFixed, kDefault } ReweightType;
 
   /** Default constructor. */
   EventWeightParameterSet() : fCovarianceMatrix(nullptr), fRWType(kDefault) {}
@@ -98,6 +102,7 @@ public:
    * @param covIndex Optional Index in the (optional) covariance matrix
    */
   void AddParameter(std::string name, float width, float mean=0, size_t covIndex=0);
+  void AddParameter(std::string name, std::vector<float> widths, float mean=0, size_t covIndex=0);
 
   /**
    * Specify a covariance matrix for correlated throws.


### PR DESCRIPTION
This PR is related to https://github.com/SBNSoftware/sbncode/issues/238, which adds additional mode, multisigma for the GENIE reweight module (based on [elease/SBN2021C](https://github.com/SBNSoftware/sbnobj/tree/release/SBN2021C)).

The enum `rwtype` is reorderd;
`kDefault` is set to -1, as it returns error when this mode is set :  https://github.com/SBNSoftware/sbnobj/blob/caed02335d6c4be34b1b97748b97ae17e56550fa/sbnobj/Common/SBNEventWeight/EventWeightParameterSet.cxx#L52-L55