### PR TITLE
Change Time Data Type for CRTHit and CRTTrack

### DIFF
--- a/sbnobj/Common/CRT/CRTHit.hh
+++ b/sbnobj/Common/CRT/CRTHit.hh
@@ -27,11 +27,11 @@ namespace sbn::crt {
       float         peshit; ///< Total photo-electron (PE) in a crt hit.
      
       uint64_t       ts0_s; ///< Second-only part of timestamp T0.
-      int8_t    ts0_s_corr; ///< [Honestly, not sure at this point, it was there since long time (BB)]
+      double    ts0_s_corr; ///< [Honestly, not sure at this point, it was there since long time (BB)]
       
-      uint64_t      ts0_ns; ///< Timestamp T0 (from White Rabbit), in UTC absolute time scale in nanoseconds from the Epoch.
-      int8_t   ts0_ns_corr; ///< [Honestly, not sure at this point, it was there since long time (BB)]
-      int64_t       ts1_ns; ///< Timestamp T1 ([signal time w.r.t. Trigger time]), in UTC absolute time scale in nanoseconds from the Epoch.
+      double        ts0_ns; ///< Timestamp T0 (from White Rabbit), in UTC absolute time scale in nanoseconds from the Epoch.
+      double   ts0_ns_corr; ///< [Honestly, not sure at this point, it was there since long time (BB)]
+      double        ts1_ns; ///< Timestamp T1 ([signal time w.r.t. Trigger time]), in UTC absolute time scale in nanoseconds from the Epoch.
      
       int            plane; ///< Name of the CRT wall (in the form of numbers).
 
@@ -46,8 +46,8 @@ namespace sbn::crt {
 
       CRTHit() {}
 
-      int64_t ts0() const { return static_cast<int64_t>(ts0_s) * 1'000'000'000LL + ts0_ns; }
-      int64_t ts1() const { return static_cast<int64_t>(ts0_s) * 1'000'000'000LL + ts1_ns; }
+      int64_t ts0() const { return static_cast<int64_t>(ts0_s) * 1'000'000'000LL + static_cast<int64_t>(ts0_ns); }
+      int64_t ts1() const { return static_cast<int64_t>(ts0_s) * 1'000'000'000LL + static_cast<int64_t>(ts1_ns); }
 
     };
 

--- a/sbnobj/Common/CRT/CRTHit.hh
+++ b/sbnobj/Common/CRT/CRTHit.hh
@@ -22,17 +22,17 @@ namespace sbn::crt {
 
     struct CRTHit{
 
-      std::vector<uint8_t> feb_id; ///< FEB address 
+      std::vector<uint8_t> feb_id; ///< FEB address
       std::map< uint8_t, std::vector<std::pair<int,float> > > pesmap; ///< Saves signal hit information (FEB, local-channel and PE) .
       float         peshit; ///< Total photo-electron (PE) in a crt hit.
-     
+
       uint64_t       ts0_s; ///< Second-only part of timestamp T0.
       double    ts0_s_corr; ///< [Honestly, not sure at this point, it was there since long time (BB)]
-      
+
       double        ts0_ns; ///< Timestamp T0 (from White Rabbit), in UTC absolute time scale in nanoseconds from the Epoch.
       double   ts0_ns_corr; ///< [Honestly, not sure at this point, it was there since long time (BB)]
       double        ts1_ns; ///< Timestamp T1 ([signal time w.r.t. Trigger time]), in UTC absolute time scale in nanoseconds from the Epoch.
-     
+
       int            plane; ///< Name of the CRT wall (in the form of numbers).
 
       float          x_pos; ///< position in x-direction (cm).

--- a/sbnobj/Common/CRT/CRTTrack.hh
+++ b/sbnobj/Common/CRT/CRTTrack.hh
@@ -20,8 +20,6 @@ namespace sbn::crt {
 
   struct CRTTrack{
 
-    std::vector<uint8_t> feb_id;
-    std::map< uint8_t, std::vector<std::pair<int,float> > > pesmap;
     float peshit; ///< Total photoelectrons for this track (sum of PEs from the two CRTHits)
     double ts0_s; ///< Average time (second) of the two hits making the track
     double ts0_s_err; ///< Average time (second) spread of the two hits making the track

--- a/sbnobj/Common/CRT/CRTTrack.hh
+++ b/sbnobj/Common/CRT/CRTTrack.hh
@@ -23,12 +23,12 @@ namespace sbn::crt {
     std::vector<uint8_t> feb_id;
     std::map< uint8_t, std::vector<std::pair<int,float> > > pesmap;
     float peshit;
-    uint32_t ts0_s;
-    uint16_t ts0_s_err;
-    uint32_t ts0_ns;
-    uint16_t ts0_ns_err;
-    int32_t ts1_ns; 
-    uint16_t ts1_ns_err;                                                                                              
+    double ts0_s;
+    double ts0_s_err;
+    double ts0_ns;
+    double ts0_ns_err;
+    double ts1_ns; 
+    double ts1_ns_err;                                                                                              
     int plane1;
     int plane2;
                            
@@ -47,10 +47,10 @@ namespace sbn::crt {
     float length;
     float thetaxy;
     float phizy;
-    uint32_t ts0_ns_h1;
-    uint16_t ts0_ns_err_h1;
-    uint32_t ts0_ns_h2;
-    uint16_t ts0_ns_err_h2;
+    double ts0_ns_h1;
+    double ts0_ns_err_h1;
+    double ts0_ns_h2;
+    double ts0_ns_err_h2;
 
     bool complete;
        

--- a/sbnobj/Common/CRT/CRTTrack.hh
+++ b/sbnobj/Common/CRT/CRTTrack.hh
@@ -22,37 +22,37 @@ namespace sbn::crt {
 
     std::vector<uint8_t> feb_id;
     std::map< uint8_t, std::vector<std::pair<int,float> > > pesmap;
-    float peshit;
-    double ts0_s;
-    double ts0_s_err;
-    double ts0_ns;
-    double ts0_ns_err;
-    double ts1_ns;
-    double ts1_ns_err;
-    int plane1;
-    int plane2;
+    float peshit; ///< Total photoelectrons for this track (sum of PEs from the two CRTHits)
+    double ts0_s; ///< Average time (second) of the two hits making the track
+    double ts0_s_err; ///< Average time (second) spread of the two hits making the track
+    double ts0_ns; ///< Average T0 (nanosecond) of the two hits making the track
+    double ts0_ns_err; ///< Error on average T0 (nanosecond) of the two hits making the track
+    double ts1_ns; ///< Average T1 (nanosecond) of the two hits making the track
+    double ts1_ns_err; ///< Error on average T1 (nanosecond) of the two hits making the track
+    int plane1; ///< Plane ID of first CRTHit
+    int plane2; ///< Plane ID of second CRTHit
 
-    float x1_pos;
-    float x1_err;
-    float y1_pos;
-    float y1_err;
-    float z1_pos;
-    float z1_err;
-    float x2_pos;
-    float x2_err;
-    float y2_pos;
-    float y2_err;
-    float z2_pos;
-    float z2_err;
-    float length;
-    float thetaxy;
-    float phizy;
-    double ts0_ns_h1;
-    double ts0_ns_err_h1;
-    double ts0_ns_h2;
-    double ts0_ns_err_h2;
+    float x1_pos; ///< X position of first CRTHit
+    float x1_err; ///< X position error of first CRTHit
+    float y1_pos; ///< Y position of first CRTHit
+    float y1_err; ///< Y position error of first CRTHit
+    float z1_pos; ///< Z position of first CRTHit
+    float z1_err; ///< Z position error of first CRTHit
+    float x2_pos; ///< X position of second CRTHit
+    float x2_err; ///< X position error of second CRTHit
+    float y2_pos; ///< Y position of second CRTHit
+    float y2_err; ///< Y position error of second CRTHit
+    float z2_pos; ///< Z position of second CRTHit
+    float z2_err; ///< Z position error of second CRTHit
+    float length; ///< Track length
+    float thetaxy;  ///< Track angle on the X-Y plane
+    float phizy; ///< Track angle on the Z-Y plane
+    double ts0_ns_h1; ///< T0 time of first CRTHit
+    double ts0_ns_err_h1; ///< T0 time error of first CRTHit
+    double ts0_ns_h2; ///< T0 time of second CRTHit
+    double ts0_ns_err_h2; ///< T0 time error of second CRTHit
 
-    bool complete;
+    bool complete; ///< Whether or not the track is complete
 
     CRTTrack() {}
 

--- a/sbnobj/Common/CRT/CRTTrack.hh
+++ b/sbnobj/Common/CRT/CRTTrack.hh
@@ -17,7 +17,7 @@
 #include <map>
 
 namespace sbn::crt {
-  
+
   struct CRTTrack{
 
     std::vector<uint8_t> feb_id;
@@ -27,11 +27,11 @@ namespace sbn::crt {
     double ts0_s_err;
     double ts0_ns;
     double ts0_ns_err;
-    double ts1_ns; 
-    double ts1_ns_err;                                                                                              
+    double ts1_ns;
+    double ts1_ns_err;
     int plane1;
     int plane2;
-                           
+
     float x1_pos;
     float x1_err;
     float y1_pos;
@@ -53,11 +53,11 @@ namespace sbn::crt {
     double ts0_ns_err_h2;
 
     bool complete;
-       
+
     CRTTrack() {}
-    
+
   };
-  
+
 } // namespace sbn::crt
 
 #endif

--- a/sbnobj/Common/CRT/classes_def.xml
+++ b/sbnobj/Common/CRT/classes_def.xml
@@ -20,7 +20,7 @@
   <class name="art::Wrapper< std::vector<sbn::crt::CRTTzero> >"/>
 
   <class name="sbn::crt::CRTTrack" ClassVersion="11">
-   <version ClassVersion="11" checksum="3493836226"/>
+   <version ClassVersion="11" checksum="197963098"/>
    <version ClassVersion="10" checksum="3848331120"/>
   </class>
   <class name="std::vector<sbn::crt::CRTTrack>"/>

--- a/sbnobj/Common/CRT/classes_def.xml
+++ b/sbnobj/Common/CRT/classes_def.xml
@@ -1,6 +1,7 @@
 <lcgdict>
 
-  <class name="sbn::crt::CRTHit" ClassVersion="16">
+  <class name="sbn::crt::CRTHit" ClassVersion="17">
+   <version ClassVersion="17" checksum="1557935027"/>
    <version ClassVersion="16" checksum="2855597518"/>
    <version ClassVersion="15" checksum="3264936168"/>
    <version ClassVersion="14" checksum="1503901052"/>
@@ -18,7 +19,8 @@
   <class name="std::vector<sbn::crt::CRTTzero>"/>
   <class name="art::Wrapper< std::vector<sbn::crt::CRTTzero> >"/>
 
-  <class name="sbn::crt::CRTTrack" ClassVersion="10">
+  <class name="sbn::crt::CRTTrack" ClassVersion="11">
+   <version ClassVersion="11" checksum="3493836226"/>
    <version ClassVersion="10" checksum="3848331120"/>
   </class>
   <class name="std::vector<sbn::crt::CRTTrack>"/>


### PR DESCRIPTION
As discussed in issue #51, this PR changes the data type for time variables from `unsigned int` to `double` for both CRTHits and CRTTracks. Resolves #51.

The main change is in commit [393f861](https://github.com/SBNSoftware/sbnobj/pull/52/commits/393f8610371f0903303c8874779dd75917bbab68).