### PR TITLE
Feature/jskim init width sbn2022 a

### DIFF
--- a/sbnobj/Common/SBNEventWeight/EventWeightParameterSet.h
+++ b/sbnobj/Common/SBNEventWeight/EventWeightParameterSet.h
@@ -21,9 +21,7 @@ struct EventWeightParameter {
 
   /** Constructor specifying all parameter properties. */
   EventWeightParameter(std::string name, float mean, float width, size_t covIndex=0)
-      : fName(name), fMean(mean), fWidth(width), fCovIndex(covIndex) {
-    fWidths.clear();
-  }
+      : fName(name), fMean(mean), fWidth(width), fCovIndex(covIndex) {}
 
   EventWeightParameter(std::string name, float mean, std::vector<float> widths, size_t covIndex=0)
       : fName(name), fMean(mean), fWidth(0), fCovIndex(covIndex), fWidths(widths) {}

--- a/sbnobj/Common/SBNEventWeight/EventWeightParameterSet.h
+++ b/sbnobj/Common/SBNEventWeight/EventWeightParameterSet.h
@@ -21,10 +21,12 @@ struct EventWeightParameter {
 
   /** Constructor specifying all parameter properties. */
   EventWeightParameter(std::string name, float mean, float width, size_t covIndex=0)
-      : fName(name), fMean(mean), fWidth(width), fCovIndex(covIndex) {}
+      : fName(name), fMean(mean), fWidth(width), fCovIndex(covIndex) {
+    fWidths.clear();
+  }
 
   EventWeightParameter(std::string name, float mean, std::vector<float> widths, size_t covIndex=0)
-      : fName(name), fMean(mean), fCovIndex(covIndex), fWidths(widths) {}
+      : fName(name), fMean(mean), fWidth(0), fCovIndex(covIndex), fWidths(widths) {}
 
   /** Comparison operator (required for use as an std::map key). */
   inline friend bool operator<(const EventWeightParameter& lhs,
@@ -38,7 +40,8 @@ struct EventWeightParameter {
     return (lhs.fName == rhs.fName &&
             lhs.fMean == rhs.fMean &&
             lhs.fWidth == rhs.fWidth &&
-            lhs.fCovIndex == rhs.fCovIndex);
+            lhs.fCovIndex == rhs.fCovIndex &&
+            lhs.fWidths == rhs.fWidths);
   }
 
   std::string fName;  //!< Parameter name


### PR DESCRIPTION
This is same as https://github.com/SBNSoftware/sbnobj/pull/56 which was based on develop, but quite critical to prevent errors when running CAFMakers on multiple input files. We can merge the same thing to this production branch.