### PR TITLE
Addition of trigger information in CAF files. Addition of time within beam gate to the CAFs for ICARUS data

### DIFF
--- a/sbnobj/Common/CMakeLists.txt
+++ b/sbnobj/Common/CMakeLists.txt
@@ -6,4 +6,4 @@ add_subdirectory(Reco)
 add_subdirectory(SBNEventWeight)
 add_subdirectory(POTAccounting)
 add_subdirectory(EventGen)
-
+add_subdirectory(Trigger)

--- a/sbnobj/Common/Trigger/BeamBits.h
+++ b/sbnobj/Common/Trigger/BeamBits.h
@@ -47,16 +47,16 @@ namespace sbn {
     // --- BEGIN -- Generic bit functions --------------------------------------
     /// @name Generic bit functions
     /// @{
-    //template <typename EnumType>
-    //using mask_t = std::underlying_type_t<EnumType>;
     
+    /// Type for bit masks.
+    /// @note This is a glorified integral type.
     template <typename EnumType>
-      struct mask_t {
-	using bits_t = EnumType; ///< Enumeration type of the bits.
-	using maskbits_t = std::underlying_type_t<EnumType>; ///< Bit data type.
-	maskbits_t bits { 0 };
-	operator maskbits_t() const { return bits; }
-      }; // mask_t
+    struct mask_t {
+      using bits_t = EnumType; ///< Enumeration type of the bits.
+      using maskbits_t = std::underlying_type_t<EnumType>; ///< Bit data type.
+      maskbits_t bits { 0 };
+      operator maskbits_t() const { return bits; }
+    }; // mask_t
 
     /// Converts a integral type into a mask.
     template <typename EnumType>
@@ -66,24 +66,24 @@ namespace sbn {
     
     /// Returns the value of specified `bit` (conversion like `enum` to `int`).
     template <typename EnumType>
-      constexpr auto value(EnumType bit);
+    constexpr auto value(EnumType bit);
     
     /// Returns a mask with all specified bits set.
     template <typename EnumType, typename... OtherBits>
-      constexpr mask_t<EnumType> mask(EnumType bit, OtherBits... otherBits);
+    constexpr mask_t<EnumType> mask(EnumType bit, OtherBits... otherBits);
     
     /// Returns whether the specified `bit` is set in `bitMask`.
     template <typename EnumType>
-      constexpr bool hasBitSet(mask_t<EnumType> bitMask, EnumType bit);
+    constexpr bool hasBitSet(mask_t<EnumType> bitMask, EnumType bit);
     
     /// Returns the name of the specified `bit`. Delegates to `bitName()`.
     template <typename EnumType>
-      std::string name(EnumType bit);
+    std::string name(EnumType bit);
     
     /// Returns a list of the names of all the bits set in `mask`.
     /// Mask is interpreted as made of only bits of type `EnumType`.
     template <typename EnumType>
-      std::vector<std::string> names(mask_t<EnumType> mask);
+    std::vector<std::string> names(mask_t<EnumType> mask);
     
     /// @}
     // --- END ---- Generic bit functions --------------------------------------
@@ -96,14 +96,14 @@ namespace sbn {
     /// Type of beam or beam gate or other trigger source.
     enum class triggerSource: unsigned int {
       Unknown,     ///< Type of beam unknown.
-	BNB,         ///< Type of beam: BNB.
-	NuMI,        ///< Type of beam: NuMI.
-	OffbeamBNB,  ///< Type of Offbeam: BNB
-	OffbeamNuMI, ///< Type of Offbeam: NuMI
-	Calib,     ///< Type of Offbeam: Calibration
-	// ==> add here if more are needed <==
-	NBits    ///< Number of bits currently supported.
-	}; // triggerSource
+      BNB,         ///< Type of beam: BNB.
+      NuMI,        ///< Type of beam: NuMI.
+      OffbeamBNB,  ///< Type of Offbeam: BNB
+      OffbeamNuMI, ///< Type of Offbeam: NuMI
+      Calib,     ///< Type of Offbeam: Calibration
+      // ==> add here if more are needed <==
+      NBits    ///< Number of bits currently supported.
+    }; // triggerSource
 
     /// Type of mask with `triggerSource` bits.
     using triggerSourceMask = mask_t<triggerSource>;
@@ -112,14 +112,14 @@ namespace sbn {
     /// Location or locations generating a trigger.
     enum class triggerLocation: unsigned int {
       CryoEast,    ///< A trigger happened in the east cryostat.
-	CryoWest,    ///< A trigger happened in the west cryostat.
-	TPCEE,       ///< A trigger happened in the east cryostat, east TPC.
-	TPCEW,       ///< A trigger happened in the east cryostat, west TPC.
-	TPCWE,       ///< A trigger happened in the west cryostat, east TPC.
-	TPCWW,       ///< A trigger happened in the west cryostat, west TPC.
-	// ==> add here if more are needed <==
-	NBits    ///< Number of bits currently supported.
-	}; // triggerLocation
+      CryoWest,    ///< A trigger happened in the west cryostat.
+      TPCEE,       ///< A trigger happened in the east cryostat, east TPC.
+      TPCEW,       ///< A trigger happened in the east cryostat, west TPC.
+      TPCWE,       ///< A trigger happened in the west cryostat, east TPC.
+      TPCWW,       ///< A trigger happened in the west cryostat, west TPC.
+      // ==> add here if more are needed <==
+      NBits    ///< Number of bits currently supported.
+    }; // triggerLocation
 
     /// Type of mask with `triggerLocation` bits.
     using triggerLocationMask = mask_t<triggerLocation>;
@@ -127,10 +127,10 @@ namespace sbn {
     /// Type representing the type(s) of this trigger.
     enum class triggerType: unsigned int {
       Majority,    ///< A minimum number of close-by PMT pairs above threshold was reached.
-	MinimumBias, ///< Data collected at gate opening with no further requirement imposed.
-	// ==> add here if more are needed <==
-	NBits    ///< Number of bits currently supported.
-	}; // triggerType
+      MinimumBias, ///< Data collected at gate opening with no further requirement imposed.
+      // ==> add here if more are needed <==
+      NBits    ///< Number of bits currently supported.
+    }; // triggerType
 
     /// Type of mask with `triggerType` bits.
     using triggerTypeMask = mask_t<triggerType>;
@@ -138,38 +138,38 @@ namespace sbn {
     /// Trigger window mode
     enum class triggerWindowMode: unsigned int {
       Separated,    ///< Separated, non-overlapping contigous window
-	Overlapping,  ///< Overlaping windows
-	//==> add here if more are needed <==
-	NBits     ///< Number of Bits currently supported
-	};
+      Overlapping,  ///< Overlaping windows
+      //==> add here if more are needed <==
+      NBits     ///< Number of Bits currently supported
+    };
 
     
 
     /// Enabled gates in the trigger configuration. See register 0X00050008 in docdb SBN-doc-23778-v1
     enum class gateSelection: unsigned int {
       GateBNB,                     ///<Enable receiving BNB early warning signal (gatedBES) to open BNB gates
-	DriftGateBNB,                ///<Enable BNB early-early warning signal ($1D) for light out-of-time in BNB gates
-	GateNuMI,                    ///<Enable NuMI early warning signal (MIBS$74) to open NuMI gates
-	DriftGateNuMI,               ///<Enable receiving NuMI early-early warning signal ($AD) for light out-of-time in NuMI gates
-	GateOffbeamBNB,              ///<Enable Offbeam gate for BNB
-	DriftGateOffbeamBNB,         ///<Enable Offbeam drift gate BNB (for light out-of-time in offbeam gates)
-	GateOffbeamNuMI,             ///<Enable Offbeam gate for NuMI
-	DriftGateOffbeamNuMI,        ///<Enable Offbeam drift gate NuMI (for light out-of-time in offbeam gates)
-	GateCalibration,             ///<Enable Calibration gate
-	DriftGateCalibration,        ///<Enable Calibration drift gate (for light out-of-time in calibration gates)
-	MinbiasGateBNB,              ///<Enable MinBias triggers for the BNB stream
-	MinbiasGateNuMI,             ///<Enable MinBias triggers for the NuMI stream
-	MinbiasGateOffbeamBNB,       ///<Enabke MinBias triggers for the Offbeam BNB stream
-	MinbiasGateOffbeamNuMI,      ///<Enable MinBias triggers for the Offbeam NuMI stream
-	MinbiasGateCalibration,      ///<Enable MinBias triggers for the Calibration stream
-	MinbiasDriftGateBNB,         ///<Enable light out-of-time for MinBias triggers in BNB stream
-	MinbiasDriftGateNuMI,        ///<Enable light out-of-time for MinBias triggers in NuMI stream
-	MinbiasDriftGateOffbeamBNB,  ///<Enable light out-of-time for MinBias triggers in Offbeam BNB stream
-	MinbiasDriftGateOffbeamNuMI, ///<Enable light out-of-time for MinBias triggers in Offbeam NuMI stream
-	MinbiasDriftGateCalibration, ///<Enable light out-of-time for MinBias triggers in Calibration stream
-	// ==> add here if more are needed <==
+      DriftGateBNB,                ///<Enable BNB early-early warning signal ($1D) for light out-of-time in BNB gates
+      GateNuMI,                    ///<Enable NuMI early warning signal (MIBS$74) to open NuMI gates
+      DriftGateNuMI,               ///<Enable receiving NuMI early-early warning signal ($AD) for light out-of-time in NuMI gates
+      GateOffbeamBNB,              ///<Enable Offbeam gate for BNB
+      DriftGateOffbeamBNB,         ///<Enable Offbeam drift gate BNB (for light out-of-time in offbeam gates)
+      GateOffbeamNuMI,             ///<Enable Offbeam gate for NuMI
+      DriftGateOffbeamNuMI,        ///<Enable Offbeam drift gate NuMI (for light out-of-time in offbeam gates)
+      GateCalibration,             ///<Enable Calibration gate
+      DriftGateCalibration,        ///<Enable Calibration drift gate (for light out-of-time in calibration gates)
+      MinbiasGateBNB,              ///<Enable MinBias triggers for the BNB stream
+      MinbiasGateNuMI,             ///<Enable MinBias triggers for the NuMI stream
+      MinbiasGateOffbeamBNB,       ///<Enabke MinBias triggers for the Offbeam BNB stream
+      MinbiasGateOffbeamNuMI,      ///<Enable MinBias triggers for the Offbeam NuMI stream
+      MinbiasGateCalibration,      ///<Enable MinBias triggers for the Calibration stream
+      MinbiasDriftGateBNB,         ///<Enable light out-of-time for MinBias triggers in BNB stream
+      MinbiasDriftGateNuMI,        ///<Enable light out-of-time for MinBias triggers in NuMI stream
+      MinbiasDriftGateOffbeamBNB,  ///<Enable light out-of-time for MinBias triggers in Offbeam BNB stream
+      MinbiasDriftGateOffbeamNuMI, ///<Enable light out-of-time for MinBias triggers in Offbeam NuMI stream
+      MinbiasDriftGateCalibration, ///<Enable light out-of-time for MinBias triggers in Calibration stream
+      // ==> add here if more are needed <==
       NBits
-	}; // gateSelection
+    }; // gateSelection
 
     using gateSelectionMask = mask_t<gateSelection>;
 
@@ -207,18 +207,18 @@ namespace sbn {
 template <typename EnumType>
 auto sbn::bits::makeMask  (typename mask_t<EnumType>::maskbits_t bits) noexcept
   -> mask_t<EnumType>
-{ return { bits }; }
+  { return { bits }; }
 
 
 // -----------------------------------------------------------------------------
 template <typename EnumType>
 constexpr auto sbn::bits::value(EnumType bit)
-{ return static_cast<std::underlying_type_t<EnumType>>(bit); }
+  { return static_cast<std::underlying_type_t<EnumType>>(bit); }
 
 
 // -----------------------------------------------------------------------------
 template <typename EnumType, typename... OtherBits>
-  constexpr auto sbn::bits::mask(EnumType bit, OtherBits... otherBits)
+constexpr auto sbn::bits::mask(EnumType bit, OtherBits... otherBits)
   -> mask_t<EnumType>
 {
   unsigned int m { 1U << value(bit) };
@@ -230,13 +230,13 @@ template <typename EnumType, typename... OtherBits>
 // -----------------------------------------------------------------------------
 template <typename EnumType>
 constexpr bool sbn::bits::hasBitSet(mask_t<EnumType> bitMask, EnumType bit)
-{ return bitMask & mask(bit); }
+  { return bitMask & mask(bit); }
 
 
 // -----------------------------------------------------------------------------
 template <typename EnumType>
 std::string sbn::bits::name(EnumType bit)
-{ return bitName(bit); }
+  { return bitName(bit); }
   
   
 // -----------------------------------------------------------------------------
@@ -254,8 +254,8 @@ std::vector<std::string> sbn::bits::names(mask_t<EnumType> mask) {
     auto const typedBit = static_cast<EnumType>(bit);
     if (!hasBitSet(mask, typedBit)) continue;
     names.push_back((bit > NSupportedBits)
-		    ? "<unsupported ["s + std::to_string(bit) + "]>"s: name(typedBit)
-		    );
+      ? "<unsupported ["s + std::to_string(bit) + "]>"s: name(typedBit)
+      );
   } // for
   return names;
   
@@ -268,16 +268,16 @@ inline std::string sbn::bits::bitName(triggerSource bit) {
   
   using namespace std::string_literals;
   switch (bit) {
-  case triggerSource::Unknown:     return "unknown"s;
-  case triggerSource::BNB:         return "BNB"s;
-  case triggerSource::NuMI:        return "NuMI"s;
-  case triggerSource::OffbeamBNB:  return "OffbeamBNB"s;
-  case triggerSource::OffbeamNuMI: return "OffbeamNuMI"s;
-  case triggerSource::Calib:       return "Calib"s;
-  case triggerSource::NBits:       return "<invalid>"s;
+    case triggerSource::Unknown:     return "unknown"s;
+    case triggerSource::BNB:         return "BNB"s;
+    case triggerSource::NuMI:        return "NuMI"s;
+    case triggerSource::OffbeamBNB:  return "OffbeamBNB"s;
+    case triggerSource::OffbeamNuMI: return "OffbeamNuMI"s;
+    case triggerSource::Calib:       return "Calib"s;
+    case triggerSource::NBits:       return "<invalid>"s;
   } // switch
   throw std::runtime_error("sbn::bits::bitName(triggerSource{ "s
-			   + std::to_string(value(bit)) + " }): unknown bit"s);
+    + std::to_string(value(bit)) + " }): unknown bit"s);
 } // sbn::bitName()
 
 // -----------------------------------------------------------------------------
@@ -286,16 +286,16 @@ inline std::string sbn::bits::bitName(triggerLocation bit) {
 
   using namespace std::string_literals;
   switch (bit) {
-  case triggerLocation::CryoEast: return "Cryo E"s;
-  case triggerLocation::CryoWest: return "Cryo W"s;
-  case triggerLocation::TPCEE:    return "TPC EE"s;
-  case triggerLocation::TPCEW:    return "TPC EW"s;
-  case triggerLocation::TPCWE:    return "TPC WE"s;
-  case triggerLocation::TPCWW:    return "TPC WW"s;
-  case triggerLocation::NBits:    return "<invalid>"s;
+    case triggerLocation::CryoEast: return "Cryo E"s;
+    case triggerLocation::CryoWest: return "Cryo W"s;
+    case triggerLocation::TPCEE:    return "TPC EE"s;
+    case triggerLocation::TPCEW:    return "TPC EW"s;
+    case triggerLocation::TPCWE:    return "TPC WE"s;
+    case triggerLocation::TPCWW:    return "TPC WW"s;
+    case triggerLocation::NBits:    return "<invalid>"s;
   } // switch
   throw std::runtime_error("sbn::bits::bitName(triggerLocation{ "s
-			   + std::to_string(value(bit)) + " }): unknown bit"s);
+    + std::to_string(value(bit)) + " }): unknown bit"s);
 } // sbn::bitName(triggerLocation)
 
 // -----------------------------------------------------------------------------
@@ -303,24 +303,24 @@ inline std::string sbn::bits::bitName(triggerType bit) {
 
   using namespace std::string_literals;
   switch (bit) {
-  case triggerType::Majority:    return "majority"s;
-  case triggerType::MinimumBias: return "minimum bias"s;
-  case triggerType::NBits:       return "<invalid>"s;
+    case triggerType::Majority:    return "majority"s;
+    case triggerType::MinimumBias: return "minimum bias"s;
+    case triggerType::NBits:       return "<invalid>"s;
   } // switch
   throw std::runtime_error("sbn::bits::bitName(triggerType{ "s
-			   + std::to_string(value(bit)) + " }): unknown bit"s);
+    + std::to_string(value(bit)) + " }): unknown bit"s);
 } // sbn::bitName(triggerType)
 
 inline std::string sbn::bits::bitName(triggerWindowMode bit) {
 
   using namespace std::string_literals;
   switch (bit) {
-  case sbn::bits::triggerWindowMode::Separated:    return "Separated Window"s;
-  case sbn::bits::triggerWindowMode::Overlapping:  return "Overlapping Window"s;
-  case sbn::bits::triggerWindowMode::NBits:    return "<invalid>"s;
+    case sbn::bits::triggerWindowMode::Separated:    return "Separated Window"s;
+    case sbn::bits::triggerWindowMode::Overlapping:  return "Overlapping Window"s;
+    case sbn::bits::triggerWindowMode::NBits:    return "<invalid>"s;
   } // switch
   throw std::runtime_error("sbn::bits::bitName(triggerWindowMode{ "s
-			   + std::to_string(value(bit)) + " }): unknown bit"s);
+    + std::to_string(value(bit)) + " }): unknown bit"s);
 } // triggerWindowMode
 
 
@@ -328,30 +328,30 @@ inline std::string sbn::bits::bitName(gateSelection bit) {
 
   using namespace std::string_literals;
   switch (bit) {
-  case gateSelection::GateBNB:                     return "GateBNB"s;
-  case gateSelection::DriftGateBNB:                return "DriftGateBNB"s;
-  case gateSelection::GateNuMI:                    return "GateNuMI"s;
-  case gateSelection::DriftGateNuMI:               return "DriftGateNuMI"s;
-  case gateSelection::GateOffbeamBNB:              return "GateOffbeamBNB"s;
-  case gateSelection::DriftGateOffbeamBNB:         return "DriftGateOffbeamBNB"s;
-  case gateSelection::GateOffbeamNuMI:             return "GateOffbeamNuMI"s;
-  case gateSelection::DriftGateOffbeamNuMI:        return "DriftGateOffbeamNuMI"s;
-  case gateSelection::GateCalibration:             return "GateCalibration"s;
-  case gateSelection::DriftGateCalibration:        return "DriftGateCalibration"s;
-  case gateSelection::MinbiasGateBNB:              return "MinbiasGateBNB"s;
-  case gateSelection::MinbiasGateNuMI:             return "MinbiasGateNuMI"s;
-  case gateSelection::MinbiasGateOffbeamBNB:       return "MinbiasGateOffbeamBNB"s;
-  case gateSelection::MinbiasGateOffbeamNuMI:      return "MinbiasGateOffbeamNuMI"s;
-  case gateSelection::MinbiasGateCalibration:      return "MinbiasGateCalibration"s;
-  case gateSelection::MinbiasDriftGateBNB:         return "MinbiasDriftGateBNB"s;
-  case gateSelection::MinbiasDriftGateNuMI:        return "MinbiasDriftGateNuMI"s;
-  case gateSelection::MinbiasDriftGateOffbeamBNB:  return "MinbiasDriftGateOffbeamBNB"s;
-  case gateSelection::MinbiasDriftGateOffbeamNuMI: return "MinbiasDriftGateOffbeamNuMI"s;
-  case gateSelection::MinbiasDriftGateCalibration: return "MinbiasDriftGateCalibration"s;
-  case gateSelection::NBits:                       return "NBits"s;
+    case gateSelection::GateBNB:                     return "GateBNB"s;
+    case gateSelection::DriftGateBNB:                return "DriftGateBNB"s;
+    case gateSelection::GateNuMI:                    return "GateNuMI"s;
+    case gateSelection::DriftGateNuMI:               return "DriftGateNuMI"s;
+    case gateSelection::GateOffbeamBNB:              return "GateOffbeamBNB"s;
+    case gateSelection::DriftGateOffbeamBNB:         return "DriftGateOffbeamBNB"s;
+    case gateSelection::GateOffbeamNuMI:             return "GateOffbeamNuMI"s;
+    case gateSelection::DriftGateOffbeamNuMI:        return "DriftGateOffbeamNuMI"s;
+    case gateSelection::GateCalibration:             return "GateCalibration"s;
+    case gateSelection::DriftGateCalibration:        return "DriftGateCalibration"s;
+    case gateSelection::MinbiasGateBNB:              return "MinbiasGateBNB"s;
+    case gateSelection::MinbiasGateNuMI:             return "MinbiasGateNuMI"s;
+    case gateSelection::MinbiasGateOffbeamBNB:       return "MinbiasGateOffbeamBNB"s;
+    case gateSelection::MinbiasGateOffbeamNuMI:      return "MinbiasGateOffbeamNuMI"s;
+    case gateSelection::MinbiasGateCalibration:      return "MinbiasGateCalibration"s;
+    case gateSelection::MinbiasDriftGateBNB:         return "MinbiasDriftGateBNB"s;
+    case gateSelection::MinbiasDriftGateNuMI:        return "MinbiasDriftGateNuMI"s;
+    case gateSelection::MinbiasDriftGateOffbeamBNB:  return "MinbiasDriftGateOffbeamBNB"s;
+    case gateSelection::MinbiasDriftGateOffbeamNuMI: return "MinbiasDriftGateOffbeamNuMI"s;
+    case gateSelection::MinbiasDriftGateCalibration: return "MinbiasDriftGateCalibration"s;
+    case gateSelection::NBits:                       return "NBits"s;
   } // switch
   throw std::runtime_error("sbn::bits::bitName(gateSelection{ "s
-			   + std::to_string(value(bit)) + " }): unknown bit"s);
+    + std::to_string(value(bit)) + " }): unknown bit"s);
 } // sbn::bitName()
 
 

--- a/sbnobj/Common/Trigger/BeamBits.h
+++ b/sbnobj/Common/Trigger/BeamBits.h
@@ -1,0 +1,379 @@
+/**
+ * @file   sbnobj/Common/Trigger/BeamBits.h
+ * @brief  Definitions of the trigger bits for SBN.
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date   May 19, 2021
+ * 
+ * This is a header-only library.
+ * 
+ * @todo This header should be moved into the proper place
+ *       (proposal: `sbnobj/Common/Trigger` in `sbnobj`)
+ */
+
+#ifndef SBNOBJ_COMMON_TRIGGER_BEAMBITS_H
+#define SBNOBJ_COMMON_TRIGGER_BEAMBITS_H
+
+
+// C/C++ standard libraries
+#include <stdexcept> // std::runtime_error
+#include <string>
+#include <vector>
+#include <initializer_list>
+#include <type_traits> // std::underlying_type_t
+
+
+// -----------------------------------------------------------------------------
+/**
+ * @brief Set of values to identify a beam.
+ * 
+ * The constants are used to identify the gate during which a trigger is
+ * acquired, in the `raw::Trigger::TriggerBits()` bit mask.
+ */
+namespace sbn {
+  
+  /**
+   * @brief Simple utilities to deal with bit enumerators.
+   * 
+   * A few simple concepts:
+   * * a bit is identified by its position (integral number: `0`, `1`, `2`...)
+   * * representation of a bit is via a enumerator (`enum class`)
+   * * bits may be associated with a name (`name()`)
+   * * to test bits, `mask()`, `value()` and `hasBitSet()` help with the
+   *   conversions between `enum class` and the underlying integral type
+   * 
+   */
+  namespace bits {
+    
+    // --- BEGIN -- Generic bit functions --------------------------------------
+    /// @name Generic bit functions
+    /// @{
+    //template <typename EnumType>
+    //using mask_t = std::underlying_type_t<EnumType>;
+    
+    template <typename EnumType>
+      struct mask_t {
+	using bits_t = EnumType; ///< Enumeration type of the bits.
+	using maskbits_t = std::underlying_type_t<EnumType>; ///< Bit data type.
+	maskbits_t bits { 0 };
+	operator maskbits_t() const { return bits; }
+      }; // mask_t
+
+    /// Converts a integral type into a mask.
+    template <typename EnumType>
+    mask_t<EnumType> makeMask
+      (typename mask_t<EnumType>::maskbits_t bits) noexcept;
+    
+    
+    /// Returns the value of specified `bit` (conversion like `enum` to `int`).
+    template <typename EnumType>
+      constexpr auto value(EnumType bit);
+    
+    /// Returns a mask with all specified bits set.
+    template <typename EnumType, typename... OtherBits>
+      constexpr mask_t<EnumType> mask(EnumType bit, OtherBits... otherBits);
+    
+    /// Returns whether the specified `bit` is set in `bitMask`.
+    template <typename EnumType>
+      constexpr bool hasBitSet(mask_t<EnumType> bitMask, EnumType bit);
+    
+    /// Returns the name of the specified `bit`. Delegates to `bitName()`.
+    template <typename EnumType>
+      std::string name(EnumType bit);
+    
+    /// Returns a list of the names of all the bits set in `mask`.
+    /// Mask is interpreted as made of only bits of type `EnumType`.
+    template <typename EnumType>
+      std::vector<std::string> names(mask_t<EnumType> mask);
+    
+    /// @}
+    // --- END ---- Generic bit functions --------------------------------------
+    
+    
+    // --- BEGIN -- Beam bits --------------------------------------------------
+    /// @name Beam bits
+    /// @{
+    
+    /// Type of beam or beam gate or other trigger source.
+    enum class triggerSource: unsigned int {
+      Unknown,     ///< Type of beam unknown.
+	BNB,         ///< Type of beam: BNB.
+	NuMI,        ///< Type of beam: NuMI.
+	OffbeamBNB,  ///< Type of Offbeam: BNB
+	OffbeamNuMI, ///< Type of Offbeam: NuMI
+	Calib,     ///< Type of Offbeam: Calibration
+	// ==> add here if more are needed <==
+	NBits    ///< Number of bits currently supported.
+	}; // triggerSource
+
+    /// Type of mask with `triggerSource` bits.
+    using triggerSourceMask = mask_t<triggerSource>;
+
+    
+    /// Location or locations generating a trigger.
+    enum class triggerLocation: unsigned int {
+      CryoEast,    ///< A trigger happened in the east cryostat.
+	CryoWest,    ///< A trigger happened in the west cryostat.
+	TPCEE,       ///< A trigger happened in the east cryostat, east TPC.
+	TPCEW,       ///< A trigger happened in the east cryostat, west TPC.
+	TPCWE,       ///< A trigger happened in the west cryostat, east TPC.
+	TPCWW,       ///< A trigger happened in the west cryostat, west TPC.
+	// ==> add here if more are needed <==
+	NBits    ///< Number of bits currently supported.
+	}; // triggerLocation
+
+    /// Type of mask with `triggerLocation` bits.
+    using triggerLocationMask = mask_t<triggerLocation>;
+
+    /// Type representing the type(s) of this trigger.
+    enum class triggerType: unsigned int {
+      Majority,    ///< A minimum number of close-by PMT pairs above threshold was reached.
+	MinimumBias, ///< Data collected at gate opening with no further requirement imposed.
+	// ==> add here if more are needed <==
+	NBits    ///< Number of bits currently supported.
+	}; // triggerType
+
+    /// Type of mask with `triggerType` bits.
+    using triggerTypeMask = mask_t<triggerType>;
+    
+    /// Trigger window mode
+    enum class triggerWindowMode: unsigned int {
+      Separated,    ///< Separated, non-overlapping contigous window
+	Overlapping,  ///< Overlaping windows
+	//==> add here if more are needed <==
+	NBits     ///< Number of Bits currently supported
+	};
+
+    
+
+    /// Enabled gates in the trigger configuration. See register 0X00050008 in docdb SBN-doc-23778-v1
+    enum class gateSelection: unsigned int {
+      GateBNB,                     ///<Enable receiving BNB early warning signal (gatedBES) to open BNB gates
+	DriftGateBNB,                ///<Enable BNB early-early warning signal ($1D) for light out-of-time in BNB gates
+	GateNuMI,                    ///<Enable NuMI early warning signal (MIBS$74) to open NuMI gates
+	DriftGateNuMI,               ///<Enable receiving NuMI early-early warning signal ($AD) for light out-of-time in NuMI gates
+	GateOffbeamBNB,              ///<Enable Offbeam gate for BNB
+	DriftGateOffbeamBNB,         ///<Enable Offbeam drift gate BNB (for light out-of-time in offbeam gates)
+	GateOffbeamNuMI,             ///<Enable Offbeam gate for NuMI
+	DriftGateOffbeamNuMI,        ///<Enable Offbeam drift gate NuMI (for light out-of-time in offbeam gates)
+	GateCalibration,             ///<Enable Calibration gate
+	DriftGateCalibration,        ///<Enable Calibration drift gate (for light out-of-time in calibration gates)
+	MinbiasGateBNB,              ///<Enable MinBias triggers for the BNB stream
+	MinbiasGateNuMI,             ///<Enable MinBias triggers for the NuMI stream
+	MinbiasGateOffbeamBNB,       ///<Enabke MinBias triggers for the Offbeam BNB stream
+	MinbiasGateOffbeamNuMI,      ///<Enable MinBias triggers for the Offbeam NuMI stream
+	MinbiasGateCalibration,      ///<Enable MinBias triggers for the Calibration stream
+	MinbiasDriftGateBNB,         ///<Enable light out-of-time for MinBias triggers in BNB stream
+	MinbiasDriftGateNuMI,        ///<Enable light out-of-time for MinBias triggers in NuMI stream
+	MinbiasDriftGateOffbeamBNB,  ///<Enable light out-of-time for MinBias triggers in Offbeam BNB stream
+	MinbiasDriftGateOffbeamNuMI, ///<Enable light out-of-time for MinBias triggers in Offbeam NuMI stream
+	MinbiasDriftGateCalibration, ///<Enable light out-of-time for MinBias triggers in Calibration stream
+	// ==> add here if more are needed <==
+      NBits
+	}; // gateSelection
+
+    using gateSelectionMask = mask_t<gateSelection>;
+
+    /// Returns a mnemonic short name of the beam type.
+    std::string bitName(triggerSource bit);
+    /// Returns a mnemonic short name of the trigger location.
+    std::string bitName(triggerLocation bit);
+    /// Returns a mnemonic short name of the trigger type.
+    std::string bitName(triggerType bit);
+    /// Returns a mnemonic short name for the trigger window mode.
+    std::string bitName(triggerWindowMode bit);
+    /// Returns a mnemonic short name for the trigger window mode.
+    std::string bitName(gateSelection bit);
+
+    /// @}
+    // --- END ---- Beam bits --------------------------------------------------
+
+  } // namespace bits
+  
+  using bits::triggerSource; // import symbol
+  using bits::triggerSourceMask;
+  using bits::triggerType;
+  using bits::triggerTypeMask;
+  using bits::triggerLocation;
+  using bits::triggerLocationMask;
+  using bits::triggerWindowMode;
+  using bits::gateSelection;
+  
+} // namespace sbn
+
+
+// -----------------------------------------------------------------------------
+// ---  inline and template implementation
+// -----------------------------------------------------------------------------
+template <typename EnumType>
+auto sbn::bits::makeMask  (typename mask_t<EnumType>::maskbits_t bits) noexcept
+  -> mask_t<EnumType>
+{ return { bits }; }
+
+
+// -----------------------------------------------------------------------------
+template <typename EnumType>
+constexpr auto sbn::bits::value(EnumType bit)
+{ return static_cast<std::underlying_type_t<EnumType>>(bit); }
+
+
+// -----------------------------------------------------------------------------
+template <typename EnumType, typename... OtherBits>
+  constexpr auto sbn::bits::mask(EnumType bit, OtherBits... otherBits)
+  -> mask_t<EnumType>
+{
+  unsigned int m { 1U << value(bit) };
+  if constexpr(sizeof...(OtherBits) > 0U) m |= mask(otherBits...);
+  return { m };
+} // sbn::mask()
+
+
+// -----------------------------------------------------------------------------
+template <typename EnumType>
+constexpr bool sbn::bits::hasBitSet(mask_t<EnumType> bitMask, EnumType bit)
+{ return bitMask & mask(bit); }
+
+
+// -----------------------------------------------------------------------------
+template <typename EnumType>
+std::string sbn::bits::name(EnumType bit)
+{ return bitName(bit); }
+  
+  
+// -----------------------------------------------------------------------------
+template <typename EnumType>
+std::vector<std::string> sbn::bits::names(mask_t<EnumType> mask) {
+  static_assert(value(EnumType::NBits) >= 0);
+  
+  using namespace std::string_literals;
+  
+  constexpr std::size_t MaxBits = sizeof(mask) * 8U;
+  constexpr std::size_t NSupportedBits = value(EnumType::NBits);
+  
+  std::vector<std::string> names;
+  for (std::size_t bit = 0U; bit < MaxBits; ++bit) {
+    auto const typedBit = static_cast<EnumType>(bit);
+    if (!hasBitSet(mask, typedBit)) continue;
+    names.push_back((bit > NSupportedBits)
+		    ? "<unsupported ["s + std::to_string(bit) + "]>"s: name(typedBit)
+		    );
+  } // for
+  return names;
+  
+} // sbn::bits::names()
+
+
+// -----------------------------------------------------------------------------
+/// @todo Move into an implementation file once this header in the final location.
+inline std::string sbn::bits::bitName(triggerSource bit) {
+  
+  using namespace std::string_literals;
+  switch (bit) {
+  case triggerSource::Unknown:     return "unknown"s;
+  case triggerSource::BNB:         return "BNB"s;
+  case triggerSource::NuMI:        return "NuMI"s;
+  case triggerSource::OffbeamBNB:  return "OffbeamBNB"s;
+  case triggerSource::OffbeamNuMI: return "OffbeamNuMI"s;
+  case triggerSource::Calib:       return "Calib"s;
+  case triggerSource::NBits:       return "<invalid>"s;
+  } // switch
+  throw std::runtime_error("sbn::bits::bitName(triggerSource{ "s
+			   + std::to_string(value(bit)) + " }): unknown bit"s);
+} // sbn::bitName()
+
+// -----------------------------------------------------------------------------
+
+inline std::string sbn::bits::bitName(triggerLocation bit) {
+
+  using namespace std::string_literals;
+  switch (bit) {
+  case triggerLocation::CryoEast: return "Cryo E"s;
+  case triggerLocation::CryoWest: return "Cryo W"s;
+  case triggerLocation::TPCEE:    return "TPC EE"s;
+  case triggerLocation::TPCEW:    return "TPC EW"s;
+  case triggerLocation::TPCWE:    return "TPC WE"s;
+  case triggerLocation::TPCWW:    return "TPC WW"s;
+  case triggerLocation::NBits:    return "<invalid>"s;
+  } // switch
+  throw std::runtime_error("sbn::bits::bitName(triggerLocation{ "s
+			   + std::to_string(value(bit)) + " }): unknown bit"s);
+} // sbn::bitName(triggerLocation)
+
+// -----------------------------------------------------------------------------
+inline std::string sbn::bits::bitName(triggerType bit) {
+
+  using namespace std::string_literals;
+  switch (bit) {
+  case triggerType::Majority:    return "majority"s;
+  case triggerType::MinimumBias: return "minimum bias"s;
+  case triggerType::NBits:       return "<invalid>"s;
+  } // switch
+  throw std::runtime_error("sbn::bits::bitName(triggerType{ "s
+			   + std::to_string(value(bit)) + " }): unknown bit"s);
+} // sbn::bitName(triggerType)
+
+inline std::string sbn::bits::bitName(triggerWindowMode bit) {
+
+  using namespace std::string_literals;
+  switch (bit) {
+  case sbn::bits::triggerWindowMode::Separated:    return "Separated Window"s;
+  case sbn::bits::triggerWindowMode::Overlapping:  return "Overlapping Window"s;
+  case sbn::bits::triggerWindowMode::NBits:    return "<invalid>"s;
+  } // switch
+  throw std::runtime_error("sbn::bits::bitName(triggerWindowMode{ "s
+			   + std::to_string(value(bit)) + " }): unknown bit"s);
+} // triggerWindowMode
+
+
+inline std::string sbn::bits::bitName(gateSelection bit) {
+
+  using namespace std::string_literals;
+  switch (bit) {
+  case gateSelection::GateBNB:                     return "GateBNB"s;
+  case gateSelection::DriftGateBNB:                return "DriftGateBNB"s;
+  case gateSelection::GateNuMI:                    return "GateNuMI"s;
+  case gateSelection::DriftGateNuMI:               return "DriftGateNuMI"s;
+  case gateSelection::GateOffbeamBNB:              return "GateOffbeamBNB"s;
+  case gateSelection::DriftGateOffbeamBNB:         return "DriftGateOffbeamBNB"s;
+  case gateSelection::GateOffbeamNuMI:             return "GateOffbeamNuMI"s;
+  case gateSelection::DriftGateOffbeamNuMI:        return "DriftGateOffbeamNuMI"s;
+  case gateSelection::GateCalibration:             return "GateCalibration"s;
+  case gateSelection::DriftGateCalibration:        return "DriftGateCalibration"s;
+  case gateSelection::MinbiasGateBNB:              return "MinbiasGateBNB"s;
+  case gateSelection::MinbiasGateNuMI:             return "MinbiasGateNuMI"s;
+  case gateSelection::MinbiasGateOffbeamBNB:       return "MinbiasGateOffbeamBNB"s;
+  case gateSelection::MinbiasGateOffbeamNuMI:      return "MinbiasGateOffbeamNuMI"s;
+  case gateSelection::MinbiasGateCalibration:      return "MinbiasGateCalibration"s;
+  case gateSelection::MinbiasDriftGateBNB:         return "MinbiasDriftGateBNB"s;
+  case gateSelection::MinbiasDriftGateNuMI:        return "MinbiasDriftGateNuMI"s;
+  case gateSelection::MinbiasDriftGateOffbeamBNB:  return "MinbiasDriftGateOffbeamBNB"s;
+  case gateSelection::MinbiasDriftGateOffbeamNuMI: return "MinbiasDriftGateOffbeamNuMI"s;
+  case gateSelection::MinbiasDriftGateCalibration: return "MinbiasDriftGateCalibration"s;
+  case gateSelection::NBits:                       return "NBits"s;
+  } // switch
+  throw std::runtime_error("sbn::bits::bitName(gateSelection{ "s
+			   + std::to_string(value(bit)) + " }): unknown bit"s);
+} // sbn::bitName()
+
+
+namespace icarus::trigger {
+
+  using triggerLocation = sbn::triggerLocation;
+  using triggerSource   = sbn::triggerSource;
+
+  static constexpr std::size_t kEast             = sbn::bits::value<triggerLocation>(triggerLocation::CryoEast);
+  static constexpr std::size_t kWest             = sbn::bits::value<triggerLocation>(triggerLocation::CryoWest);
+  static constexpr std::size_t kNTriggerLocation = sbn::bits::value<triggerLocation>(triggerLocation::NBits);
+
+  static constexpr std::size_t kBNB            = sbn::bits::value<triggerSource>(triggerSource::BNB);
+  static constexpr std::size_t kNuMI           = sbn::bits::value<triggerSource>(triggerSource::NuMI);
+  static constexpr std::size_t kOffBeamBNB     = sbn::bits::value<triggerSource>(triggerSource::OffbeamBNB);
+  static constexpr std::size_t kOffBeamNuMI    = sbn::bits::value<triggerSource>(triggerSource::OffbeamNuMI);
+  static constexpr std::size_t kCalibration    = sbn::bits::value<triggerSource>(triggerSource::Calib);
+  static constexpr std::size_t kNTriggerSource = sbn::bits::value<triggerSource>(triggerSource::NBits);
+
+}
+
+
+// -----------------------------------------------------------------------------
+
+#endif // SBNOBJ_COMMON_TRIGGER_BEAMBITS_H

--- a/sbnobj/Common/Trigger/CMakeLists.txt
+++ b/sbnobj/Common/Trigger/CMakeLists.txt
@@ -1,0 +1,11 @@
+cet_make(
+  LIBRARIES
+    ${ROOT_BASIC_LIB_LIST}	
+  NO_DICTIONARY
+)
+
+
+art_dictionary(DICTIONARY_LIBRARIES sbnobj_Common_Trigger)
+
+install_headers()
+install_source()

--- a/sbnobj/Common/Trigger/ExtraTriggerInfo.cxx
+++ b/sbnobj/Common/Trigger/ExtraTriggerInfo.cxx
@@ -1,0 +1,206 @@
+/**
+ * @file sbnobj/Common/Trigger/ExtraTriggerInfo.cxx
+ * @brief Data product holding additional trigger information.
+ * @authors Gianluca Petrillo (petrillo@slac.stanford.edu),
+ *          Jacob Zettlemoyer (jzettle@fnal.gov>)
+ * @date June 18, 2021
+ * @see sbnobj/Common/Trigger/ExtraTriggerInfo.h
+ */
+
+#include "sbnobj/Common/Trigger/ExtraTriggerInfo.h"
+
+// C/C++ standard library
+#include <ostream>
+#include <iomanip> // std::setfill(), std::setw()
+
+
+// -----------------------------------------------------------------------------
+namespace {
+  
+  // ---------------------------------------------------------------------------
+  template <typename T = std::uint64_t>
+    struct TimestampDumper { T timestamp; };
+  
+  template <typename T>
+    TimestampDumper<T> dumpTimestamp(T timestamp)
+    { return { timestamp }; }
+  
+  template <typename T>
+    std::ostream& operator<< (std::ostream& out, TimestampDumper<T> wrapper) {
+    T const timestamp = wrapper.timestamp;
+    //std::uint64_t const timestamp = wrapper.timestamp;
+    if (sbn::ExtraTriggerInfo::isValidTimestamp(timestamp)) {
+      out << (timestamp / 1'000'000'000) << "."
+        << std::setfill('0') << std::setw(9) << (timestamp % 1'000'000'000)
+	  << " s";
+    }
+    else out << "<n/a>";
+    return out;
+  } // operator<< (TimestampDumper)
+  
+  
+  // ---------------------------------------------------------------------------
+  struct TriggerIDdumper { unsigned int ID; };
+  
+  TriggerIDdumper dumpTriggerID(unsigned int ID) { return { ID }; }
+  
+  std::ostream& operator<< (std::ostream& out, TriggerIDdumper wrapper) {
+    unsigned int const ID = wrapper.ID;
+    if (sbn::ExtraTriggerInfo::isValidID(ID)) out << ID;
+    else                                      out << "<n/a>";
+    return out;
+  } // operator<< (TriggerIDdumper)
+  
+  
+  // ---------------------------------------------------------------------------
+  struct TriggerCountDumper { unsigned int count; };
+  
+  TriggerCountDumper dumpTriggerCount(unsigned int count) { return { count }; }
+  
+  std::ostream& operator<< (std::ostream& out, TriggerCountDumper wrapper) {
+    unsigned int const count = wrapper.count;
+    if (sbn::ExtraTriggerInfo::isValidCount(count)) out << count;
+    else                                            out << "<n/a>";
+    return out;
+  } // operator<< (TriggerCountDumper)
+  
+  
+  // ---------------------------------------------------------------------------
+  long long int timestampDiff(std::uint64_t timestamp, std::uint64_t ref) {
+    return static_cast<long long int>
+      ((timestamp > ref)? (timestamp - ref): (ref - timestamp));
+  }
+  
+  
+  // ---------------------------------------------------------------------------
+
+  struct LVDSmaskDumper { std::uint64_t bits; };
+
+  LVDSmaskDumper dumpLVDSmask(std::uint64_t bits) { return { bits }; }
+
+  std::ostream& operator<< (std::ostream& out, LVDSmaskDumper wrapper) {
+    std::uint64_t const bits { wrapper.bits };
+
+    auto dumpBoard = [&out](std::uint8_t bits)
+      {
+        static constexpr char symbols[2] = { '-', 'x' };
+	std::uint8_t mask = 0x80;
+        do { out << symbols[(bits & mask)? 1: 0]; } while (mask >>= 1);
+      };
+    auto boardBits = [](std::uint64_t bits, short int board) -> std::uint8_t
+      { return static_cast<std::uint8_t>((bits >> (board * 8)) & 0xFF); };
+
+    // positions 3 and 7 are empty 
+    dumpBoard(boardBits(bits, 6));
+    out << ' ';
+    dumpBoard(boardBits(bits, 5));
+    out << ' ';
+    dumpBoard(boardBits(bits, 4));
+    out << ' ';
+    out << ' ';
+    dumpBoard(boardBits(bits, 2));
+    out << ' ';
+    dumpBoard(boardBits(bits, 1));
+    out << ' ';
+    dumpBoard(boardBits(bits, 0));
+
+    return out;
+  } // operator<< (LVDSmaskDumper)            
+
+  
+} // local namespace
+
+
+// -----------------------------------------------------------------------------
+std::ostream& sbn::operator<< (std::ostream& out, ExtraTriggerInfo const& info)
+{
+  if (!info.isValid()) {
+    out << "<invalid>";
+    return out;
+  }
+  
+  // quite a load:
+  out
+    <<   "trigger ID=" << dumpTriggerID(info.triggerID) << " from source "
+    << name(info.sourceType)
+    << " at " << dumpTimestamp(info.triggerTimestamp)
+    << " on beam gate ID=" << dumpTriggerID(info.gateID)
+    << " at " << dumpTimestamp(info.beamGateTimestamp)
+      << " (diff: "
+    << timestampDiff(info.beamGateTimestamp, info.triggerTimestamp) << " ns)"
+    << "\n"
+    << "enable gate opened at " << dumpTimestamp(info.enableGateTimestamp)
+    << " (" << timestampDiff(info.beamGateTimestamp, info.enableGateTimestamp)
+    << " ns before the gate)"
+    << "\n"
+      << "counts from this source: trigger="
+    << dumpTriggerCount(info.triggerCount)
+    << " beam=" << dumpTriggerCount(info.gateCount)
+    << "\n"
+      << "previous trigger from this source at "
+    << dumpTimestamp(info.previousTriggerTimestamp)
+      << ", triggers since: "
+    << dumpTriggerCount(info.anyTriggerCountFromPreviousTrigger)
+      << ", gates since: "
+    << dumpTriggerCount(info.anyGateCountFromPreviousTrigger)
+      << " ("
+    << dumpTriggerCount(info.gateCountFromPreviousTrigger)
+      << " from this same source)"
+    << "\n"
+      << "most recent trigger was from source "
+    << name(info.anyPreviousTriggerSourceType) << " at "
+    << dumpTimestamp(info.anyPreviousTriggerTimestamp)
+    ;
+  if (sbn::ExtraTriggerInfo::isValidTimestamp(info.anyPreviousTriggerTimestamp)
+      && sbn::ExtraTriggerInfo::isValidTimestamp(info.triggerTimestamp))
+    {
+    out
+      << " ("
+      << dumpTimestamp(info.triggerTimestamp - info.anyPreviousTriggerTimestamp)
+      << " earlier)";
+    }
+  out
+      << ", and "
+      << dumpTriggerCount(info.anyGateCountFromAnyPreviousTrigger)
+      << " gates from any source have opened since"
+    ;
+  if (info.WRtimeToTriggerTime != ExtraTriggerInfo::UnknownCorrection) {
+    out << "\nCorrection applied to the timestamps: "
+	<< dumpTimestamp(info.WRtimeToTriggerTime);
+  }
+  if (info.triggerLocationBits != 0) {
+    out << "\nLocation(s) of trigger:";
+    for (std::string const& bitName: names(info.triggerLocation()))
+      out << " " << bitName;
+  }
+  out << "\nWest cryostat: "
+      << info.cryostats[ExtraTriggerInfo::WestCryostat].triggerCount
+      << " triggers";
+  if (auto const& cryo = info.cryostats[ExtraTriggerInfo::WestCryostat];
+      cryo.hasLVDS()
+      ) {
+    out
+      << "\n  west wall:  "
+      << dumpLVDSmask(cryo.LVDSstatus[ExtraTriggerInfo::WestPMTwall])
+      << "\n  east wall:  "
+      << dumpLVDSmask(cryo.LVDSstatus[ExtraTriggerInfo::EastPMTwall])
+      ;
+  }
+
+  out << "\nEast cryostat: "
+      << info.cryostats[ExtraTriggerInfo::EastCryostat].triggerCount
+      << " triggers";
+  if (auto const& cryo = info.cryostats[ExtraTriggerInfo::EastCryostat];
+      cryo.hasLVDS()
+      ) {
+    out
+      << "\n  west wall:  "
+      << dumpLVDSmask(cryo.LVDSstatus[ExtraTriggerInfo::WestPMTwall])
+      << "\n  east wall:  "
+      << dumpLVDSmask(cryo.LVDSstatus[ExtraTriggerInfo::EastPMTwall])
+      ;
+  }
+
+  
+  return out;
+} // sbn::operator<< (ExtraTriggerInfo)

--- a/sbnobj/Common/Trigger/ExtraTriggerInfo.cxx
+++ b/sbnobj/Common/Trigger/ExtraTriggerInfo.cxx
@@ -19,20 +19,19 @@ namespace {
   
   // ---------------------------------------------------------------------------
   template <typename T = std::uint64_t>
-    struct TimestampDumper { T timestamp; };
+  struct TimestampDumper { T timestamp; };
   
   template <typename T>
-    TimestampDumper<T> dumpTimestamp(T timestamp)
+  TimestampDumper<T> dumpTimestamp(T timestamp)
     { return { timestamp }; }
   
   template <typename T>
-    std::ostream& operator<< (std::ostream& out, TimestampDumper<T> wrapper) {
+  std::ostream& operator<< (std::ostream& out, TimestampDumper<T> wrapper) {
     T const timestamp = wrapper.timestamp;
-    //std::uint64_t const timestamp = wrapper.timestamp;
     if (sbn::ExtraTriggerInfo::isValidTimestamp(timestamp)) {
       out << (timestamp / 1'000'000'000) << "."
         << std::setfill('0') << std::setw(9) << (timestamp % 1'000'000'000)
-	  << " s";
+        << " s";
     }
     else out << "<n/a>";
     return out;
@@ -122,43 +121,43 @@ std::ostream& sbn::operator<< (std::ostream& out, ExtraTriggerInfo const& info)
   // quite a load:
   out
     <<   "trigger ID=" << dumpTriggerID(info.triggerID) << " from source "
-    << name(info.sourceType)
-    << " at " << dumpTimestamp(info.triggerTimestamp)
-    << " on beam gate ID=" << dumpTriggerID(info.gateID)
-    << " at " << dumpTimestamp(info.beamGateTimestamp)
+      << name(info.sourceType)
+      << " at " << dumpTimestamp(info.triggerTimestamp)
+      << " on beam gate ID=" << dumpTriggerID(info.gateID)
+      << " at " << dumpTimestamp(info.beamGateTimestamp)
       << " (diff: "
-    << timestampDiff(info.beamGateTimestamp, info.triggerTimestamp) << " ns)"
+      << timestampDiff(info.beamGateTimestamp, info.triggerTimestamp) << " ns)"
     << "\n"
     << "enable gate opened at " << dumpTimestamp(info.enableGateTimestamp)
     << " (" << timestampDiff(info.beamGateTimestamp, info.enableGateTimestamp)
     << " ns before the gate)"
     << "\n"
       << "counts from this source: trigger="
-    << dumpTriggerCount(info.triggerCount)
-    << " beam=" << dumpTriggerCount(info.gateCount)
+        << dumpTriggerCount(info.triggerCount)
+      << " beam=" << dumpTriggerCount(info.gateCount)
     << "\n"
       << "previous trigger from this source at "
-    << dumpTimestamp(info.previousTriggerTimestamp)
+      << dumpTimestamp(info.previousTriggerTimestamp)
       << ", triggers since: "
-    << dumpTriggerCount(info.anyTriggerCountFromPreviousTrigger)
+      << dumpTriggerCount(info.anyTriggerCountFromPreviousTrigger)
       << ", gates since: "
-    << dumpTriggerCount(info.anyGateCountFromPreviousTrigger)
+      << dumpTriggerCount(info.anyGateCountFromPreviousTrigger)
       << " ("
-    << dumpTriggerCount(info.gateCountFromPreviousTrigger)
+      << dumpTriggerCount(info.gateCountFromPreviousTrigger)
       << " from this same source)"
     << "\n"
       << "most recent trigger was from source "
-    << name(info.anyPreviousTriggerSourceType) << " at "
-    << dumpTimestamp(info.anyPreviousTriggerTimestamp)
+      << name(info.anyPreviousTriggerSourceType) << " at "
+      << dumpTimestamp(info.anyPreviousTriggerTimestamp)
     ;
   if (sbn::ExtraTriggerInfo::isValidTimestamp(info.anyPreviousTriggerTimestamp)
-      && sbn::ExtraTriggerInfo::isValidTimestamp(info.triggerTimestamp))
-    {
+    && sbn::ExtraTriggerInfo::isValidTimestamp(info.triggerTimestamp))
+  {
     out
       << " ("
       << dumpTimestamp(info.triggerTimestamp - info.anyPreviousTriggerTimestamp)
       << " earlier)";
-    }
+  }
   out
       << ", and "
       << dumpTriggerCount(info.anyGateCountFromAnyPreviousTrigger)
@@ -166,7 +165,7 @@ std::ostream& sbn::operator<< (std::ostream& out, ExtraTriggerInfo const& info)
     ;
   if (info.WRtimeToTriggerTime != ExtraTriggerInfo::UnknownCorrection) {
     out << "\nCorrection applied to the timestamps: "
-	<< dumpTimestamp(info.WRtimeToTriggerTime);
+      << dumpTimestamp(info.WRtimeToTriggerTime);
   }
   if (info.triggerLocationBits != 0) {
     out << "\nLocation(s) of trigger:";
@@ -204,3 +203,6 @@ std::ostream& sbn::operator<< (std::ostream& out, ExtraTriggerInfo const& info)
   
   return out;
 } // sbn::operator<< (ExtraTriggerInfo)
+
+
+// -----------------------------------------------------------------------------

--- a/sbnobj/Common/Trigger/ExtraTriggerInfo.h
+++ b/sbnobj/Common/Trigger/ExtraTriggerInfo.h
@@ -1,0 +1,293 @@
+/**
+ * @file sbnobj/Common/Trigger/ExtraTriggerInfo.h
+ * @brief Data product holding additional trigger information.
+ * @authors Gianluca Petrillo (petrillo@slac.stanford.edu),
+ *          Jacob Zettlemoyer (jzettle@fnal.gov>)
+ * @date June 18, 2021
+ * @see sbnobj/Common/Trigger/ExtraTriggerInfo.cxx
+ */
+
+#ifndef SBNOBJ_COMMON_TRIGGER_EXTRATRIGGERINFO_H
+#define SBNOBJ_COMMON_TRIGGER_EXTRATRIGGERINFO_H
+
+
+// SBN libraries
+#include "sbnobj/Common/Trigger/BeamBits.h"
+
+// C/C++ standard libraries
+#include <array>
+#include <iosfwd> // std::ostream
+#include <limits> // std::numeric_limits<>
+#include <cstdint> // std::uint64_t
+
+
+// -----------------------------------------------------------------------------
+namespace sbn { struct ExtraTriggerInfo; }
+/**
+ * @brief Additional information on trigger.
+ * 
+ * This data structure holds information from the trigger that has no place in
+ * the standard LArSoft data products (`raw::Trigger` and
+ * `raw::ExternalTrigger`).
+ * 
+ * Absolute times are counted since The Epoch and are in UTC time.
+ * 
+ * Some "historical" information is available:
+ * *  count of gates and triggers from the start of the run;
+ * *  count of gates and triggers from the previous trigger;
+ * *  timestamps of previous gates and triggers.
+ * 
+ * Some historical information is available for different gate selections:
+ * * including only triggers and gates the same source as this trigger source;
+ * * including triggers and gates from any source (tagged as "any").
+ * 
+ */
+struct sbn::ExtraTriggerInfo {
+  
+  /// Special ID value indicating the absence of an ID.
+  static constexpr unsigned int NoID = std::numeric_limits<unsigned int>::max();
+  
+  /// Special timestamp value indicating the absence of timestamp.
+  static constexpr std::uint64_t NoTimestamp
+    = std::numeric_limits<std::uint64_t>::max();
+  
+  /// Special timestamp correction value indicating an unknown correction.
+  static constexpr std::int64_t UnknownCorrection
+    = std::numeric_limits<std::int64_t>::max();
+  
+  
+  /// Type of this gate (`sbn::triggerSource::NBits` marks this object invalid).
+  sbn::triggerSource sourceType { sbn::triggerSource::NBits };
+
+  /// Type of this trigger (see `sbn::triggerType`).
+  sbn::triggerType triggerType { sbn::triggerType::NBits };
+
+  /// Absolute timestamp of the opening of the enable gate [ns]
+  std::uint64_t enableGateTimestamp { NoTimestamp };
+  
+  
+  // --- BEGIN -- Since the beginning of the run -------------------------------
+  /// @name Counters and times since the beginning of the run.
+  /// @{
+  
+  /// Absolute timestamp of this trigger [ns]
+  std::uint64_t triggerTimestamp { NoTimestamp };
+  
+  /// Absolute timestamp of the opening of this beam gate [ns]
+  std::uint64_t beamGateTimestamp { NoTimestamp };
+  
+  /// The identifier of this trigger (usually matching the event number).
+  unsigned int triggerID { NoID };
+  
+  /// Incremental counter of gates from any source opened from start of the run.
+  unsigned int gateID { 0 };
+  
+  /// Incremental counter of triggers from this source from start of the run.
+  unsigned int triggerCount { 0 };
+  
+  /// Incremental counter of gates from this source opened from start of the run.
+  unsigned int gateCount { 0 };
+  
+  /// @}
+  // --- END ---- Since the beginning of the run -------------------------------
+  
+  
+  
+  // --- BEGIN -- Since the previous trigger from this same source -------------
+  /// @name Counters since the previous trigger from this same source
+  /// @{
+  
+  /// Gates from this source since the previous trigger also of this source
+  /// (minimum is `1`: the current gate).
+  unsigned int gateCountFromPreviousTrigger { 0 };
+  
+  /// Triggers from any source since the previous trigger also of this source
+  /// (minimum is `1`: the current trigger).
+  unsigned int anyTriggerCountFromPreviousTrigger { 0 };
+  
+  /// Gates from any source since the previous trigger also of this source
+  /// (minimum is `1`: the current trigger).
+  unsigned int anyGateCountFromPreviousTrigger { 0 };
+  
+  /// @}
+  // --- END ---- Since the previous trigger from this same source -------------
+  
+  
+  // --- BEGIN -- Since the previous trigger from any source -------------------
+  /// @name Counters since the previous trigger from any source
+  /// @{
+  
+  /// Type of the previous trigger.
+  sbn::triggerSource anyPreviousTriggerSourceType
+    { sbn::triggerSource::Unknown };
+  
+  /// Gates from any source since the previous trigger also from any source
+  /// (minimum is `1`: the current gate).
+  unsigned int anyGateCountFromAnyPreviousTrigger { 0 };
+  
+  /// @}
+  // --- END ---- Since the previous trigger from any source -------------------
+  
+  
+  // --- BEGIN -- Additional timestamps ----------------------------------------
+  /// @name Additional timestamps
+  /// @{
+  
+  // we do not have timestamps of gates not associated to triggers
+  
+  /// Absolute timestamp of the previous trigger from this same source [ns]
+  std::uint64_t previousTriggerTimestamp { NoTimestamp };
+  
+  /// Absolute timestamp of the previous trigger from any source [ns]
+  std::uint64_t anyPreviousTriggerTimestamp { NoTimestamp };
+  
+  /// @}
+  // --- END ---- Additional timestamps ----------------------------------------
+  
+  
+  // --- BEGIN -- Decoding information -----------------------------------------
+  /// @name Decoding information
+  /// @{
+  
+  /// Correction added to the White Rabbit time to get the trigger time.
+  std::int64_t WRtimeToTriggerTime { UnknownCorrection };
+  
+  /// @}
+  // --- END ---- Decoding information -----------------------------------------
+
+  // --- BEGIN -- Trigger topology ---------------------------------------------
+  /**
+   * @name Trigger topology
+   * 
+   * The information is represented in groups of cryostats and, within each of
+   * them, of PMT "walls", that is groups of PMT lying on the same geometric
+   * plane (in SBN detectors that is behind each anode).
+   * 
+   * Currently the information is represented by fixed size arrays, because the
+   * overhead of a variable length container (`std::vector`) is comparable to
+   * the data itself.
+   */
+  /// @{
+  
+  /// Maximum number of cryostats in the detector.
+  static constexpr std::size_t MaxCryostats { 2 };
+  
+  /// Maximum number of PMT "walls" in a cryostat.
+  static constexpr std::size_t MaxWalls { 2 };
+
+  /// Mnemonic index for the east cryostat.
+  static constexpr std::size_t EastCryostat { 0 };
+  
+  /// Mnemonic index for the west cryostat.
+  static constexpr std::size_t WestCryostat { 1 };
+  
+  /// Mnemonic index for the east PMT wall within a cryostat.
+  static constexpr std::size_t EastPMTwall { 0 };
+  
+  /// Mnemonic index for the west PMT wall within a cryostat.
+  static constexpr std::size_t WestPMTwall { 1 };
+  
+  
+  /// Trigger data pertaining a single cryostat.
+  struct CryostatInfo {
+    /// Count of triggers in this cryostat.
+    unsigned long int triggerCount { 0 };
+    
+    /**
+     * @brief Status of LVDS signals from PMT pairs at the time of the trigger.
+     * 
+     * There is one status per PMT wall (index mnemonic constants: `EastPMTwall`
+     * and `WestPMTwall`).
+     * 
+     * 
+     * ICARUS
+     * -------
+     * 
+     * Bits are 48 per wall, 8 pairs from each on 6 PMT readout boards.
+     * For the position of the PMT generating a LVDS channel, refer to the
+     * configuration of the trigger emulation.
+     * 
+     * The 48 bits are distributed in the value as follow:
+     * * the south part (lower _z_, lower channel number) is in the first 32-bit
+     * * the north part (upper _z_, higher channel number) is in the last 32-bit
+     * 
+     * The 8 most significant bits of each 32-bit half-word are zeroed.
+     * Then the most significant bits match the lowest channel numbers (lower
+     * _z_). Splitting the detector in six regions (of 15 PMT each) so that it
+     * looks, from south to north: `AA|BB|CC|DD|EE|FF`, the bit mask of the six
+     * parts (each with 15 PMT, 8 LVDS channels, 8 bits) looks like:
+     * `00AABBCC'00DDEEFF`.
+     */
+    std::array<std::uint64_t, MaxWalls> LVDSstatus { 0U, 0U };
+    
+    /// Returns whether there is some recorded LVDS activity.
+    constexpr bool hasLVDS() const;
+    
+  }; // CryostatInfo
+  
+  
+  /// Bits for the trigger location (@see `triggerLocation()`).
+  unsigned int triggerLocationBits { 0U };
+  //sbn::triggerLocation triggerLocationBits { sbn::triggerSource::NBits  }
+  /// Status of each LVDS channel in each PMT wall at trigger time.
+  std::array<CryostatInfo, MaxCryostats> cryostats;
+  
+  /**
+   * @brief Returns the location of the trigger.
+   * 
+   * The returned value is a mask of `sbn::bits::triggerLocation` bits.
+   * To test the state of a bit, it needs to be converted into a mask, e.g.:
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+   * bool onTPCEE
+   *   = extraTriggerInfo.triggerLocation() & mask(sbn::triggerLocation::TPCEE);
+   * bool onTPCxE = extraTriggerInfo.triggerLocation()
+   *   & mask(sbn::triggerLocation::TPCEE, sbn::triggerLocation::TPCWE);
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   */
+  sbn::bits::triggerLocationMask triggerLocation() const
+    { return { triggerLocationBits }; }
+  
+  
+  /// @}
+  // --- END ---- Trigger topology ---------------------------------------------
+  
+  
+  
+  /// Returns whether this object contains any valid information.
+  constexpr bool isValid() const noexcept
+  { return sourceType != sbn::triggerSource::NBits; }
+  
+  
+  /// Returns whether the specified `ID` is valid (i.e. is not `NoID`).
+  static constexpr bool isValidID(unsigned int ID) noexcept
+  { return ID != NoID; }
+  
+  /// Returns whether the timestamp `ts` is valid (i.e. is not `NoTimestamp`).
+  static constexpr bool isValidTimestamp(std::uint64_t ts) noexcept
+  { return ts != NoTimestamp; }
+  
+  /// Returns whether the `count` is valid (i.e. is not `0`).
+  static constexpr bool isValidCount(unsigned int count) noexcept
+  { return count != 0U; }
+  
+  
+}; // sbn::ExtraTriggerInfo
+
+
+namespace sbn {
+  std::ostream& operator<< (std::ostream& out, ExtraTriggerInfo const& info);
+}
+
+// -----------------------------------------------------------------------------
+
+constexpr bool sbn::ExtraTriggerInfo::CryostatInfo::hasLVDS() const {
+  // C++20:
+  //  return std::ranges::any_of(LVDSstatus, std::identity{});   
+  for (std::uint64_t bits: LVDSstatus) if (bits) return true;
+  return false;
+} // sbn::ExtraTriggerInfo::CryostatInfo::empty()
+
+
+
+
+#endif // SBNOBJ_COMMON_TRIGGER_EXTRATRIGGERINFO_H

--- a/sbnobj/Common/Trigger/ExtraTriggerInfo.h
+++ b/sbnobj/Common/Trigger/ExtraTriggerInfo.h
@@ -255,20 +255,20 @@ struct sbn::ExtraTriggerInfo {
   
   /// Returns whether this object contains any valid information.
   constexpr bool isValid() const noexcept
-  { return sourceType != sbn::triggerSource::NBits; }
+    { return sourceType != sbn::triggerSource::NBits; }
   
   
   /// Returns whether the specified `ID` is valid (i.e. is not `NoID`).
   static constexpr bool isValidID(unsigned int ID) noexcept
-  { return ID != NoID; }
+    { return ID != NoID; }
   
   /// Returns whether the timestamp `ts` is valid (i.e. is not `NoTimestamp`).
   static constexpr bool isValidTimestamp(std::uint64_t ts) noexcept
-  { return ts != NoTimestamp; }
+    { return ts != NoTimestamp; }
   
   /// Returns whether the `count` is valid (i.e. is not `0`).
   static constexpr bool isValidCount(unsigned int count) noexcept
-  { return count != 0U; }
+    { return count != 0U; }
   
   
 }; // sbn::ExtraTriggerInfo

--- a/sbnobj/Common/Trigger/classes.h
+++ b/sbnobj/Common/Trigger/classes.h
@@ -1,0 +1,24 @@
+/**
+ * @file   sbnobj/Common/Trigger/classes.h
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date   July 10, 2019
+ * 
+ * Enables dictionary definitions for:
+ * 
+ * * `sbn::ExtraTriggerInfo`
+ * 
+ * See also `sbnobj/Common/Trigger/classes_def.xml`.
+ */
+
+// SBN libraries
+#include "sbnobj/Common/Trigger/ExtraTriggerInfo.h"
+
+// framework libraries
+#include "canvas/Persistency/Common/Ptr.h"
+#include "canvas/Persistency/Common/Wrapper.h"
+
+
+namespace {
+  
+  sbn::ExtraTriggerInfo tinfo;
+  } // local namespace

--- a/sbnobj/Common/Trigger/classes_def.xml
+++ b/sbnobj/Common/Trigger/classes_def.xml
@@ -1,0 +1,39 @@
+<!--
+  
+  ROOT dictionary generation for:
+  
+  * `sbn::ExtraTriggerInfo`
+  
+  
+  Reminder:
+  
+  * include `art::Wrapper` lines for objects that we would like to put into the event
+  * include the non-wrapper lines for all objects on the `art::Wrapper` lines
+    and for all objects that are data members of those objects.
+  
+  -->
+
+
+<lcgdict>
+  <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+  <!-- sbn::ExtraTriggerInfo -->
+
+  <!--   class -->
+  <class name="sbn::ExtraTriggerInfo" ClassVersion="10" >
+   <version ClassVersion="10" checksum="1967722932"/>
+  </class>
+  
+    <!-- dependencies -->
+    <enum name="sbn::bits::triggerSource" ClassVersion="10" />
+    <enum name="sbn::bits::triggerLocation" ClassVersion="10" />
+    <enum name="sbn::bits::triggerType" ClassVersion="10" />
+    <class name="sbn::ExtraTriggerInfo::CryostatInfo" ClassVersion="10" >
+     <version ClassVersion="10" checksum="313789291"/>
+    </class>
+
+    <!-- art pointers and wrappers -->
+    <class name="art::Ptr<sbn::ExtraTriggerInfo>"/>
+    <class name="art::Wrapper<sbn::ExtraTriggerInfo>"/>
+    <class name="std::vector<sbn::ExtraTriggerInfo>"/>
+
+  </lcgdict>


### PR DESCRIPTION
Main change is addition of trigger information and moving the `sbn::ExtraTriggerInfo` object from icaruscode to sbnobj for getting the needed object for this PR accessible to ICARUS and SBND.

Tested on ICARUS data from raw -> CAF stage and successfully computed the time within the beam gate for the data. 

Depends on equivalent PRs in icaruscode, sbncode, and sbnobj