### PR TITLE
Output of trigger gate object dump expanded.

### DIFF
--- a/sbnobj/ICARUS/PMT/Trigger/Data/TriggerGateData.tcc
+++ b/sbnobj/ICARUS/PMT/Trigger/Data/TriggerGateData.tcc
@@ -824,7 +824,9 @@ std::ostream& icarus::trigger::operator<<
   }
   else {
     auto current = iStatus->opening;
-    out << " opened at " << iStatus->tick;
+    out << " opened";
+    if (current > 1) out << " with " << current;
+    out << " at " << iStatus->tick;
     while (++iStatus != send) {
       if (iStatus->opening == current) continue;
       if ((current == 0) && (iStatus->opening > current)) {


### PR DESCRIPTION
This is a completely trivial change that lay on my branch forever. It changes the text output of a data product, with no consequence whatsoever.
I am going to stick to GitHub suggestion for the reviewer selection... but I claim that if it compiles it does not need further review.

### What is that, anyhow?

Well, a trigger gate object is a discriminated multi-level gate in time, meaning that it describes something that starts at level `0`, then it may rise to level `1`, then after a while to level `2` or back to `0`, and so forth. The output to stream shows the time when these changes happen. The change introduces printing also the level entered at the time of the change (unless it's `0` or `1`). This exception is because most often this object is used for a simple discriminator where levels are only `0` and `1`, in which case the new level is implied by the fact that there is a change.
