### PR TITLE
Additions to trigger dump information

### DIFF
--- a/sbnobj/Common/Trigger/BeamBits.h
+++ b/sbnobj/Common/Trigger/BeamBits.h
@@ -98,9 +98,9 @@ namespace sbn {
       Unknown,     ///< Type of beam unknown.
       BNB,         ///< Type of beam: BNB.
       NuMI,        ///< Type of beam: NuMI.
-      OffbeamBNB,  ///< Type of Offbeam: BNB
-      OffbeamNuMI, ///< Type of Offbeam: NuMI
-      Calib,     ///< Type of Offbeam: Calibration
+      OffbeamBNB,  ///< Type of Offbeam: BNB.
+      OffbeamNuMI, ///< Type of Offbeam: NuMI.
+      Calib,       ///< Type of source: calibration trigger.
       // ==> add here if more are needed <==
       NBits    ///< Number of bits currently supported.
     }; // triggerSource

--- a/sbnobj/Common/Trigger/ExtraTriggerInfo.cxx
+++ b/sbnobj/Common/Trigger/ExtraTriggerInfo.cxx
@@ -120,8 +120,9 @@ std::ostream& sbn::operator<< (std::ostream& out, ExtraTriggerInfo const& info)
   
   // quite a load:
   out
-    <<   "trigger ID=" << dumpTriggerID(info.triggerID) << " from source "
-      << name(info.sourceType)
+    <<   "trigger ID=" << dumpTriggerID(info.triggerID)
+      << " (type " << name(info.triggerType) << ")"
+      << " from source " << name(info.sourceType)
       << " at " << dumpTimestamp(info.triggerTimestamp)
       << " on beam gate ID=" << dumpTriggerID(info.gateID)
       << " at " << dumpTimestamp(info.beamGateTimestamp)

--- a/sbnobj/ICARUS/PMT/Trigger/Data/TriggerGateData.tcc
+++ b/sbnobj/ICARUS/PMT/Trigger/Data/TriggerGateData.tcc
@@ -824,7 +824,9 @@ std::ostream& icarus::trigger::operator<<
   }
   else {
     auto current = iStatus->opening;
-    out << " opened at " << iStatus->tick;
+    out << " opened";
+    if (current > 1) out << " with " << current;
+    out << " at " << iStatus->tick;
     while (++iStatus != send) {
       if (iStatus->opening == current) continue;
       if ((current == 0) && (iStatus->opening > current)) {


### PR DESCRIPTION
These two additions add a tiny bit of information to the dump of trigger and trigger gates.

This is not important enough to call for a new release on its own: please merge it when a new release is due because of other requests.

Picking @jzettle as reviewer because he's out of luck; not much to review anyway.