### PR TITLE
CRUMBS Multi Signal

### DIFF
--- a/sbnobj/Common/Reco/CRUMBSResult.cc
+++ b/sbnobj/Common/Reco/CRUMBSResult.cc
@@ -1,11 +1,17 @@
 #include "sbnobj/Common/Reco/CRUMBSResult.h"
 
-sbn::CRUMBSResult::CRUMBSResult(float score, float tpc_CRFracHitsInLongestTrack, float tpc_CRLongestTrackDeflection, float tpc_CRLongestTrackDirY,
+sbn::CRUMBSResult::CRUMBSResult(float score, float ccnumuscore, float ccnuescore, float ncscore, float bestscore, int bestid, 
+				float tpc_CRFracHitsInLongestTrack, float tpc_CRLongestTrackDeflection, float tpc_CRLongestTrackDirY,
 				int tpc_CRNHitsMax, float tpc_NuEigenRatioInSphere, int tpc_NuNFinalStatePfos, int tpc_NuNHitsTotal,
 				int tpc_NuNSpacePointsInSphere, float tpc_NuVertexY, float tpc_NuWeightedDirZ, float tpc_StoppingChi2CosmicRatio,
 				float pds_FMTotalScore, float pds_FMPE, float pds_FMTime, float crt_TrackScore, float crt_HitScore,
 				float crt_TrackTime, float crt_HitTime)
   : score(score)
+  , ccnumuscore(ccnumuscore)
+  , ccnuescore(ccnuescore)
+  , ncscore(ncscore)
+  , bestscore(bestscore)
+  , bestid(bestid)
   , tpc_CRFracHitsInLongestTrack(tpc_CRFracHitsInLongestTrack)
   , tpc_CRLongestTrackDeflection(tpc_CRLongestTrackDeflection)
   , tpc_CRLongestTrackDirY(tpc_CRLongestTrackDirY)

--- a/sbnobj/Common/Reco/CRUMBSResult.h
+++ b/sbnobj/Common/Reco/CRUMBSResult.h
@@ -20,7 +20,7 @@ namespace sbn {
 		 float pds_FMTotalScore = default_float, float pds_FMPE = default_float, float pds_FMTime = default_float, float crt_TrackScore = default_float, 
 		 float crt_HitScore = default_float, float crt_TrackTime = default_float, float crt_HitTime = default_float);
     
-    float score;                         //!< CRUMBS result
+    float score;                         //!< CRUMBS result, for inclusive neutrino signal
     float ccnumuscore;                   //!< CRUMBS result, for CCNuMu signal
     float ccnuescore;                    //!< CRUMBS result, for CCNuE signal
     float ncscore;                       //!< CRUMBS result, for NC signal

--- a/sbnobj/Common/Reco/CRUMBSResult.h
+++ b/sbnobj/Common/Reco/CRUMBSResult.h
@@ -12,7 +12,8 @@ namespace sbn {
   class CRUMBSResult {
   public:
 
-    CRUMBSResult(float score = default_float, float tpc_CRFracHitsInLongestTrack = default_float, float tpc_CRLongestTrackDeflection = default_float, 
+    CRUMBSResult(float score = default_float, float ccnumuscore = default_float, float ccnuescore = default_float, float ncscore = default_float, 
+		 float bestscore = default_float, int bestid = default_int, float tpc_CRFracHitsInLongestTrack = default_float, float tpc_CRLongestTrackDeflection = default_float, 
 		 float tpc_CRLongestTrackDirY = default_float, int tpc_CRNHitsMax = default_int, float tpc_NuEigenRatioInSphere = default_float, 
 		 int tpc_NuNFinalStatePfos = default_int, int tpc_NuNHitsTotal = default_int, int tpc_NuNSpacePointsInSphere = default_int, 
 		 float tpc_NuVertexY = default_float, float tpc_NuWeightedDirZ = default_float, float tpc_StoppingChi2CosmicRatio = default_float, 
@@ -20,6 +21,11 @@ namespace sbn {
 		 float crt_HitScore = default_float, float crt_TrackTime = default_float, float crt_HitTime = default_float);
     
     float score;                         //!< CRUMBS result
+    float ccnumuscore;                   //!< CRUMBS result, for CCNuMu signal
+    float ccnuescore;                    //!< CRUMBS result, for CCNuE signal
+    float ncscore;                       //!< CRUMBS result, for NC signal
+    float bestscore;                     //!< Best score from the three signal-specific versions
+    int   bestid;                        //!< ID corresponding to the best score, 14 for CCNuMu, 12 for CCNuE, 1 for NC
     float tpc_CRFracHitsInLongestTrack;  //!< fraction of slice’s space points in longest track (cosmic reco)
     float tpc_CRLongestTrackDeflection;  //!< 1 - the cosine of the angle between the starting and finishing directions of the longest track (cosmic reco)
     float tpc_CRLongestTrackDirY;        //!< relative direction of the longest track in Y (cosmic reco)

--- a/sbnobj/Common/Reco/classes_def.xml
+++ b/sbnobj/Common/Reco/classes_def.xml
@@ -51,7 +51,8 @@
   <class name="art::Assns<sbn::SimpleFlashMatch,recob::PFParticle, void>" />
   <class name="art::Wrapper<art::Assns<sbn::SimpleFlashMatch, recob::PFParticle, void> >" />
 
-  <class name="sbn::CRUMBSResult" ClassVersion="10">
+  <class name="sbn::CRUMBSResult" ClassVersion="11">
+   <version ClassVersion="11" checksum="2038758639"/>
    <version ClassVersion="10" checksum="1001500335"/>
   </class>
   <class name="std::vector<sbn::CRUMBSResult>" />


### PR DESCRIPTION
Contains the required updates to `CRUMBSResult` in order to store separate signal specific versions of the CRUMBS score.