### PR TITLE
Adding offbeam gate counting in the CAFs

### DIFF
--- a/sbnobj/Common/POTAccounting/EXTCountInfo.h
+++ b/sbnobj/Common/POTAccounting/EXTCountInfo.h
@@ -16,8 +16,8 @@ namespace sbn {
     int gates_since_last_trigger;
     bool isBNBOffBeam;
     bool isNuMIOffBeam;
-    bool isMajority;
-    bool isMinBias;
+    bool isMajority; //< Does trigger pass scintillation-based trigger?
+    bool isMinBias;  //< Is this a non-scintillation-based trigger?
 
   };
 } // end namespace sbn

--- a/sbnobj/Common/POTAccounting/EXTCountInfo.h
+++ b/sbnobj/Common/POTAccounting/EXTCountInfo.h
@@ -14,6 +14,10 @@ namespace sbn {
   public:
 
     int gates_since_last_trigger;
+    bool isBNBOffBeam;
+    bool isNuMIOffBeam;
+    bool isMajority;
+    bool isMinBias;
 
   };
 } // end namespace sbn

--- a/sbnobj/Common/POTAccounting/classes_def.xml
+++ b/sbnobj/Common/POTAccounting/classes_def.xml
@@ -11,7 +11,9 @@
    <version ClassVersion="11" checksum="4062206176"/>
    <version ClassVersion="10" checksum="3057205612"/>
   </class>
-  <class name="sbn::EXTCountInfo" ClassVersion="11">
+  <class name="sbn::EXTCountInfo" ClassVersion="13">
+   <version ClassVersion="13" checksum="90106564"/>
+   <version ClassVersion="12" checksum="3544499454"/>
    <version ClassVersion="11" checksum="2738807909"/>
    <version ClassVersion="10" checksum="1347272"/>
   </class>


### PR DESCRIPTION
This PR adds offbeam gate counting into the CAFs. The number of gates is computed as a difference with the gate counting performed within the event to compute the number of offbeam gates for BNB or NuMI seen by the trigger hardware on an event-by-event basis.