### PR TITLE
Added sbn::ExtraTriggerInfo::triggerFromBeamGate()

### DIFF
--- a/sbnobj/Common/Trigger/ExtraTriggerInfo.h
+++ b/sbnobj/Common/Trigger/ExtraTriggerInfo.h
@@ -252,6 +252,13 @@ struct sbn::ExtraTriggerInfo {
   // --- END ---- Trigger topology ---------------------------------------------
   
   
+  /// Returns the time from the beam gate to the trigger [ns].
+  /// Only valid if beam gate timestamp is valid.
+  constexpr std::int64_t triggerFromBeamGate() const
+    { 
+      return static_cast<std::int64_t>(triggerTimestamp)
+        - static_cast<std::int64_t>(beamGateTimestamp);
+    }  
   
   /// Returns whether this object contains any valid information.
   constexpr bool isValid() const noexcept


### PR DESCRIPTION
This is a simple addition to this data product interface.
The new member function returns the trigger time with respect to the beam gate time, and I added it because the conversions to signed are tedious if written correctly, so I'd rather do it once.

This is a gregarious request that should be merged only when some other thing is being merged in `sbnobj`: it's not worth its own release.
Also note that this is a GitHub edit — I trust on the C.I. test to tell if it does not compile.

I also let you choose whom to ask to review it (a.k.a. I have no idea).