### PR TITLE
Add flags & unixtime fields to FEBData object

### DIFF
--- a/sbnobj/SBND/CRT/FEBData.cxx
+++ b/sbnobj/SBND/CRT/FEBData.cxx
@@ -8,18 +8,22 @@
 namespace sbnd{
 namespace crt{
 
-  FEBData::FEBData():
-    fMac5(0)
+  FEBData::FEBData()
+  : fMac5(0)
+  , fFlags(0)
   , fTs0(0)
   , fTs1(0)
+  , fUnixS(0)
   , fADC()
   , fCoinc(0)
   {}
 
-  FEBData::FEBData(uint16_t mac5, uint32_t ts0, uint32_t ts1, adc_array_t ADC, uint32_t coinc):
-    fMac5(mac5)
+  FEBData::FEBData(uint16_t mac5, uint16_t flags, uint32_t ts0, uint32_t ts1, uint32_t unixs, adc_array_t ADC, uint32_t coinc)
+  : fMac5(mac5)
+  , fFlags(flags)
   , fTs0(ts0)
   , fTs1(ts1)
+  , fUnixS(unixs)
   , fADC(ADC)
   , fCoinc(coinc)
   {}
@@ -31,6 +35,11 @@ namespace crt{
     return fMac5;
   }
 
+  uint16_t FEBData::Flags() const
+  {
+    return fFlags;
+  }
+
   uint32_t FEBData::Ts0() const
   {
     return fTs0;
@@ -39,6 +48,11 @@ namespace crt{
   uint32_t FEBData::Ts1() const
   {
     return fTs1;
+  }
+
+  uint32_t FEBData::UnixS() const
+  {
+    return fUnixS;
   }
 
   adc_array_t FEBData::ADC() const
@@ -65,6 +79,11 @@ namespace crt{
     fMac5 = mac5;
   }
 
+  void FEBData::SetFlags(uint16_t flags)
+  {
+    fFlags = flags;
+  }
+
   void FEBData::SetTs0(uint32_t ts0)
   {
     fTs0 = ts0;
@@ -73,6 +92,11 @@ namespace crt{
   void FEBData::SetTs1(uint32_t ts1)
   {
     fTs1 = ts1;
+  }
+
+  void FEBData::SetUnixS(uint32_t unixs)
+  {
+    fUnixS = unixs;
   }
 
   void FEBData::SetADC(size_t sipmID, uint16_t adc)

--- a/sbnobj/SBND/CRT/FEBData.hh
+++ b/sbnobj/SBND/CRT/FEBData.hh
@@ -21,8 +21,10 @@ namespace sbnd::crt {
   class FEBData {
 
     uint16_t fMac5; ///< ID of the FEB
-    uint32_t fTs0; ///< T0 counter
-    uint32_t fTs1; ///< T1 counter
+    uint16_t fFlags; ///< Event flags describing the type of data recorded
+    uint32_t fTs0; ///< T0 counter [ns]
+    uint32_t fTs1; ///< T1 counter [ns]
+    uint32_t fUnixS; ///< Event time since unix epoch [s]
     adc_array_t fADC; ///< 32 ADC values, one per SiPM
     uint32_t fCoinc; ///< ID of SiPM that fired the trigger
 
@@ -34,15 +36,17 @@ namespace sbnd::crt {
     FEBData();
 
     /**
-     * Returns the ID of the CRT module.
+     * Constructor to set all parameters
      *
      * @param mac5 The ID of the CRT module (FEB).
+     * @param flags The event flags.
      * @param ts0 The value of the t0 counter.
      * @param ts1 The value of the t1 counter.
+     * @param unixs The event time since unix epoch.
      * @param ADC The 32-size array with ADC values.
      * @param coinc The ID of the strip that fired the trigger.
      */
-    FEBData(uint16_t mac5, uint32_t ts0, uint32_t ts1, adc_array_t ADC, uint32_t coinc);
+    FEBData(uint16_t mac5, uint16_t flags, uint32_t ts0, uint32_t ts1, uint32_t unixs, adc_array_t ADC, uint32_t coinc);
 
     virtual ~FEBData();
 
@@ -52,6 +56,13 @@ namespace sbnd::crt {
      * @return The MAC5 ID of this FEB data.
      */
     uint16_t Mac5() const;
+
+    /**
+     * Returns the event flags from the data taking.
+     *
+     * @return The event flags of this FEB data.
+     */
+    uint16_t Flags() const;
 
     /**
      * Returns the T0 time from the T0 counter.
@@ -66,6 +77,13 @@ namespace sbnd::crt {
      * @return The Ts1 of this FEB data.
      */
     uint32_t Ts1() const;
+
+    /**
+     * Returns the unix time of the event.
+     *
+     * @return The unix time of the FEB data.
+     */
+    uint32_t UnixS() const;
 
     /**
      * Returns the array of ACD counts from the FEB board.
@@ -100,6 +118,13 @@ namespace sbnd::crt {
     void SetMac5(uint16_t mac5);
 
     /**
+     * Setter method for flags
+     *
+     * @param flags The flags to set.
+     */
+    void SetFlags(uint16_t flags);
+
+    /**
      * Setter method for Ts0
      *
      * @param ts0 The ts0 value to set
@@ -112,6 +137,13 @@ namespace sbnd::crt {
      * @param ts1 The ts1 value to set
      */
     void SetTs1(uint32_t ts1);
+
+    /**
+     * Setter method for unix time
+     *
+     * @param unixs The unix time to set.
+     */
+    void SetUnixS(uint32_t unixs);
 
     /**
      * Adds ADC values on a certain sipm.


### PR DESCRIPTION
Following extensive work to rewrite the CRT reconstruction for SBND the PR strategy has been agreed to be a series of PRs against a common branch (`feature/hlay_crt_clustering_base`) for the (inevitably very long) review stage. Please don't use CI tests yet. They will be used on the final PR when the common branch is compared to `develop`. At this stage the individual branches may not each compile on their own. The fully merged branch can be viewed here for completeness [feature/hlay_crt_clustering_merged](https://github.com/SBNSoftware/sbnobj/tree/feature/hlay_crt_clustering_merged).

This PR adds the flags & unixtime fields to the FEBData object to better represent the real data.