### PR TITLE
Add useful enums for CRT sim/reco

### DIFF
--- a/sbnobj/SBND/CRT/CRTEnums.cxx
+++ b/sbnobj/SBND/CRT/CRTEnums.cxx
@@ -1,0 +1,20 @@
+#ifndef SBND_CRTENUMS_CXX
+#define SBND_CRTENUMS_CXX
+
+#include "sbnobj/SBND/CRT/CRTEnums.hh"
+
+sbnd::crt::CoordSet operator|(sbnd::crt::CoordSet lhs, sbnd::crt::CoordSet rhs) {
+  return static_cast<sbnd::crt::CoordSet>(
+      static_cast<std::underlying_type_t<sbnd::crt::CoordSet>>(lhs) |
+      static_cast<std::underlying_type_t<sbnd::crt::CoordSet>>(rhs)
+  );
+}
+
+sbnd::crt::CoordSet operator&(sbnd::crt::CoordSet lhs, sbnd::crt::CoordSet rhs) {
+  return static_cast<sbnd::crt::CoordSet>(
+      static_cast<std::underlying_type_t<sbnd::crt::CoordSet>>(lhs) &
+      static_cast<std::underlying_type_t<sbnd::crt::CoordSet>>(rhs)
+  );
+}
+
+#endif

--- a/sbnobj/SBND/CRT/CRTEnums.hh
+++ b/sbnobj/SBND/CRT/CRTEnums.hh
@@ -1,0 +1,53 @@
+/**
+ * \brief Definitions of enums used in CRT objects
+ *
+ * \author Henry Lay (h.lay@lancaster.ac.uk)
+ */
+
+#ifndef SBND_CRTENUMS_HH
+#define SBND_CRTENUMS_HH
+
+#include <stdint.h>
+#include <type_traits>
+
+namespace sbnd::crt {
+
+  // CRTTagger enum used to quickly refer to one of the seven SBND taggers.
+
+  enum CRTTagger {
+    kUndefinedTagger = -1,
+    kBottomTagger,
+    kSouthTagger,
+    kNorthTagger,
+    kWestTagger,
+    kEastTagger,
+    kTopLowTagger,
+    kTopHighTagger,
+
+    kUpstreamTagger   = kSouthTagger,
+    kDownstreamTagger = kNorthTagger
+  };
+
+  // Often working in 1, 2 or 3 dimensions for CRT things, this enum allows us to define this easily.
+  // It is defined like a bitset of flags such that the below operations can be defined usefully.
+
+  enum CoordSet : uint8_t {
+    kUndefinedSet = 0,
+    kX   = 1,   // 001
+    kY   = 2,   // 010
+    kZ   = 4,   // 100
+    kXY  = 3,   // 011
+    kXZ  = 5,   // 101
+    kYZ  = 6,   // 110
+    kXYZ = 7,   // 111
+
+    kThreeD = kXYZ
+
+  };
+}
+
+extern sbnd::crt::CoordSet operator|(sbnd::crt::CoordSet lhs, sbnd::crt::CoordSet rhs);
+
+extern sbnd::crt::CoordSet operator&(sbnd::crt::CoordSet lhs, sbnd::crt::CoordSet rhs);
+
+#endif


### PR DESCRIPTION
Following extensive work to rewrite the CRT reconstruction for SBND the PR strategy has been agreed to be a series of PRs against a common branch (`feature/hlay_crt_clustering_base`) for the (inevitably very long) review stage. Please don't use CI tests yet. They will be used on the final PR when the common branch is compared to `develop`. At this stage the individual branches may not each compile on their own. The fully merged branch can be viewed here for completeness [feature/hlay_crt_clustering_merged](https://github.com/SBNSoftware/sbnobj/tree/feature/hlay_crt_clustering_merged).

This PR introduces some useful enums.