### PR TITLE
Update naming for ToF object

### DIFF
--- a/sbnobj/SBND/ToF/ToF.hh
+++ b/sbnobj/SBND/ToF/ToF.hh
@@ -15,7 +15,7 @@ struct ToF {
       float crt_time = -9999; 
       float pmt_time = -9999;
       std::string crt_tagger = "N/A";
-      int crt_hit_id = -9999;
+      int crt_sp_id = -9999;
       int crt_trk_id = -9999;
       int pmt_hit_id = -9999;
       int pmt_flash_id = -9999;

--- a/sbnobj/SBND/ToF/classes_def.xml
+++ b/sbnobj/SBND/ToF/classes_def.xml
@@ -1,5 +1,6 @@
 <lcgdict>
-  <class name="sbnd::ToF::ToF" ClassVersion="10">
+  <class name="sbnd::ToF::ToF" ClassVersion="11">
+   <version ClassVersion="11" checksum="1183341127"/>
    <version ClassVersion="10" checksum="289199695"/>
   </class>
   <class name="std::vector<sbnd::ToF::ToF>"/>


### PR DESCRIPTION
Following extensive work to rewrite the CRT reconstruction for SBND the PR strategy has been agreed to be a series of PRs against a common branch (`feature/hlay_crt_clustering_base`) for the (inevitably very long) review stage. Please don't use CI tests yet. They will be used on the final PR when the common branch is compared to `develop`. At this stage the individual branches may not each compile on their own.

This PR just updates some naming in the ToF variable to ensure consistency with the new reco.