### PR TITLE
Add CRTStripHit object

### DIFF
--- a/sbnobj/SBND/CRT/CRTStripHit.cxx
+++ b/sbnobj/SBND/CRT/CRTStripHit.cxx
@@ -1,0 +1,67 @@
+#ifndef SBND_CRTSTRIPHIT_CXX
+#define SBND_CRTSTRIPHIT_CXX
+
+#include "sbnobj/SBND/CRT/CRTStripHit.hh"
+
+namespace sbnd {
+
+  namespace crt {
+
+    CRTStripHit::CRTStripHit()
+      : fChannel      (0)
+      , fTs0          (0)
+      , fTs1          (0)
+      , fUnixS        (0)
+      , fPos          (0)
+      , fErr          (0)
+      , fADC1         (0)
+      , fADC2         (0)
+      , fSaturated1   (false)
+      , fSaturated2   (false)
+    {}
+
+    CRTStripHit::CRTStripHit(uint32_t _channel, uint32_t _ts0, uint32_t _ts1, uint32_t _s, double _pos,
+                             double _err, uint16_t _adc1, uint16_t _adc2)
+      : fChannel      (_channel)
+      , fTs0          (_ts0)
+      , fTs1          (_ts1)
+      , fUnixS        (_s)
+      , fPos          (_pos)
+      , fErr          (_err)
+      , fADC1         (_adc1)
+      , fADC2         (_adc2)
+    {
+      fSaturated1 = fADC1 == 4095;
+      fSaturated2 = fADC2 == 4095;
+    }
+
+    CRTStripHit::CRTStripHit(uint32_t _channel, uint32_t _ts0, uint32_t _ts1, uint32_t _s, double _pos,
+                             double _err, uint16_t _adc1, uint16_t _adc2, bool _saturated1, bool _saturated2)
+      : fChannel      (_channel)
+      , fTs0          (_ts0)
+      , fTs1          (_ts1)
+      , fUnixS        (_s)
+      , fPos          (_pos)
+      , fErr          (_err)
+      , fADC1         (_adc1)
+      , fADC2         (_adc2)
+      , fSaturated1   (_saturated1)
+      , fSaturated2   (_saturated2)
+    {}
+
+    CRTStripHit::~CRTStripHit() {}
+
+    uint32_t CRTStripHit::Channel() const { return fChannel; }
+    uint32_t CRTStripHit::Ts0() const { return fTs0; }
+    uint32_t CRTStripHit::Ts1() const { return fTs1; }
+    uint32_t CRTStripHit::UnixS() const { return fUnixS; }
+    double   CRTStripHit::Pos() const { return fPos; }
+    double   CRTStripHit::Error() const { return fErr; }
+    uint16_t CRTStripHit::ADC1() const { return fADC1; }
+    uint16_t CRTStripHit::ADC2() const { return fADC2; }
+    bool     CRTStripHit::Saturated1() const { return fSaturated1; }
+    bool     CRTStripHit::Saturated2() const { return fSaturated2; }
+  }
+}
+
+#endif

--- a/sbnobj/SBND/CRT/CRTStripHit.hh
+++ b/sbnobj/SBND/CRT/CRTStripHit.hh
@@ -1,0 +1,55 @@
+/**
+ * \class CRTStripHit
+ *
+ * \brief Product to store 2D CRT "strip hit"
+ *
+ * \author Henry Lay (h.lay@lancaster.ac.uk)
+ *
+ */
+
+#ifndef SBND_CRTSTRIPHIT_HH
+#define SBND_CRTSTRIPHIT_HH
+
+#include <stdint.h>
+
+namespace sbnd::crt {
+
+  class CRTStripHit {
+    
+    uint32_t fChannel;      // Channel ID for 1st SiPM
+    uint32_t fTs0;          // T0 counter [ns] - Time relative to pulse-per-second
+    uint32_t fTs1;          // T1 counter [ns] - Time relative to some beam signal
+    uint32_t fUnixS;        // Unixtime of event [s]
+    double   fPos;          // Lateral position within strip [cm]
+    double   fErr;          // Error on lateral position [cm]
+    uint16_t fADC1;         // ADC 1st SiPM
+    uint16_t fADC2;         // ADC 2nd SiPM
+    bool     fSaturated1;   // Did 1st SiPM record a saturated value?
+    bool     fSaturated2;   // Did 2nd SiPM record a saturated value?
+
+  public:
+
+    CRTStripHit();
+    
+    CRTStripHit(uint32_t _channel, uint32_t _ts0, uint32_t _ts1, uint32_t _s, double _pos,
+                double _err, uint16_t _adc1, uint16_t _adc2);
+
+    CRTStripHit(uint32_t _channel, uint32_t _ts0, uint32_t _ts1, uint32_t _s, double _pos,
+                double _err, uint16_t _adc1, uint16_t _adc2, bool _saturated1, bool _saturated2);
+
+    virtual ~CRTStripHit();
+
+    uint32_t Channel() const;
+    uint32_t Ts0() const;
+    uint32_t Ts1() const;
+    uint32_t UnixS() const;
+    double   Pos() const;
+    double   Error() const;
+    uint16_t ADC1() const;
+    uint16_t ADC2() const;
+    bool     Saturated1() const;
+    bool     Saturated2() const;
+  };
+}
+
+#endif


### PR DESCRIPTION
Following extensive work to rewrite the CRT reconstruction for SBND the PR strategy has been agreed to be a series of PRs against a common branch (`feature/hlay_crt_clustering_base`) for the (inevitably very long) review stage. Please don't use CI tests yet. They will be used on the final PR when the common branch is compared to `develop`. At this stage the individual branches may not each compile on their own. The fully merged branch can be viewed here for completeness [feature/hlay_crt_clustering_merged](https://github.com/SBNSoftware/sbnobj/tree/feature/hlay_crt_clustering_merged).

This PR introduces the new CRTStripHit object which is the basic hit finding object looking for raw data above a threshold and then characterising that within a single CRT strip.