### PR TITLE
Add CRTCluster object

### DIFF
--- a/sbnobj/SBND/CRT/CRTCluster.cxx
+++ b/sbnobj/SBND/CRT/CRTCluster.cxx
@@ -1,0 +1,40 @@
+#ifndef SBND_CRTCLUSTER_CXX
+#define SBND_CRTCLUSTER_CXX
+
+#include "sbnobj/SBND/CRT/CRTCluster.hh"
+
+namespace sbnd {
+
+  namespace crt {
+
+    CRTCluster::CRTCluster()
+      : fTs0          (0)
+      , fTs1          (0)
+      , fUnixS        (0)
+      , fNHits        (0)
+      , fTagger       (kUndefinedTagger)
+      , fComposition  (kUndefinedSet)
+    {}
+
+    CRTCluster::CRTCluster(uint32_t _ts0, uint32_t _ts1, uint32_t _unixS, uint16_t _nHits, CRTTagger _tagger,
+                           CoordSet _composition)
+      : fTs0          (_ts0)
+      , fTs1          (_ts1)
+      , fUnixS        (_unixS)
+      , fNHits        (_nHits)
+      , fTagger       (_tagger)
+      , fComposition  (_composition)
+    {}
+
+    CRTCluster::~CRTCluster() {}
+
+    uint32_t  CRTCluster::Ts0() const { return fTs0; }
+    uint32_t  CRTCluster::Ts1() const { return fTs1; }
+    uint32_t  CRTCluster::UnixS() const { return fUnixS; }
+    uint16_t  CRTCluster::NHits() const { return fNHits; }
+    CRTTagger CRTCluster::Tagger() const { return fTagger; }
+    CoordSet  CRTCluster::Composition() const { return fComposition; }
+  }
+}
+
+#endif

--- a/sbnobj/SBND/CRT/CRTCluster.hh
+++ b/sbnobj/SBND/CRT/CRTCluster.hh
@@ -1,0 +1,44 @@
+/**
+ * \class CRTCluster
+ *
+ * \brief Product to store a cluster of CRTStripHits
+ *
+ * \author Henry Lay (h.lay@lancaster.ac.uk)
+ *
+ */
+
+#ifndef SBND_CRTCLUSTER_HH
+#define SBND_CRTCLUSTER_HH
+
+#include "sbnobj/SBND/CRT/CRTEnums.hh"
+
+namespace sbnd::crt {
+
+  class CRTCluster {
+    
+    uint32_t  fTs0;          // T0 counter [ns]
+    uint32_t  fTs1;          // T1 counter [ns]
+    uint32_t  fUnixS;        // Unixtime of event [s]
+    uint16_t  fNHits;        // The number of strip hits forming the cluster
+    CRTTagger fTagger;       // The tagger this cluster exists on
+    CoordSet  fComposition;  // What combination of orientations does the cluster make up?
+
+  public:
+
+    CRTCluster();
+    
+    CRTCluster(uint32_t _ts0, uint32_t _ts1, uint32_t _unixS, uint16_t _nHits, CRTTagger _tagger,
+               CoordSet _composition);
+
+    virtual ~CRTCluster();
+
+    uint32_t  Ts0() const;
+    uint32_t  Ts1() const;
+    uint32_t  UnixS() const;
+    uint16_t  NHits() const;
+    CRTTagger Tagger() const;
+    CoordSet  Composition() const;
+  };
+}
+
+#endif


### PR DESCRIPTION
Following extensive work to rewrite the CRT reconstruction for SBND the PR strategy has been agreed to be a series of PRs against a common branch (`feature/hlay_crt_clustering_base`) for the (inevitably very long) review stage. Please don't use CI tests yet. They will be used on the final PR when the common branch is compared to `develop`. At this stage the individual branches may not each compile on their own. The fully merged branch can be viewed here for completeness [feature/hlay_crt_clustering_merged](https://github.com/SBNSoftware/sbnobj/tree/feature/hlay_crt_clustering_merged).

This PR introduces the new CRTCluster object, representing a group of activity in a single tagger.