### PR TITLE
Add CRTSpacePoint object

### DIFF
--- a/sbnobj/SBND/CRT/CRTSpacePoint.cxx
+++ b/sbnobj/SBND/CRT/CRTSpacePoint.cxx
@@ -1,0 +1,55 @@
+#ifndef SBND_CRTSPACEPOINT_CXX
+#define SBND_CRTSPACEPOINT_CXX
+
+#include "sbnobj/SBND/CRT/CRTSpacePoint.hh"
+
+namespace sbnd {
+
+  namespace crt {
+
+    CRTSpacePoint::CRTSpacePoint()
+      : fPos      ({0., 0., 0.})
+      , fPosErr   ({0., 0., 0.})
+      , fPE       (0.)
+      , fTime     (0.)
+      , fTimeErr  (0.)
+      , fComplete (false)
+    {}
+
+    CRTSpacePoint::CRTSpacePoint(double _x, double _ex, double _y, double _ey, double _z, double _ez, 
+                                 double _pe, double _time, double _etime, bool _complete)
+      : fPos      ({_x, _y, _z})
+      , fPosErr   ({_ex, _ey, _ez})
+      , fPE       (_pe)
+      , fTime     (_time)
+      , fTimeErr  (_etime)
+      , fComplete (_complete)
+    {}
+
+    CRTSpacePoint::CRTSpacePoint(geo::Point_t _pos, geo::Point_t _err, double _pe, double _time, double _etime, bool _complete)
+      : fPos      (_pos)
+      , fPosErr   (_err)
+      , fPE       (_pe)
+      , fTime     (_time)
+      , fTimeErr  (_etime)
+      , fComplete (_complete)
+    {}
+
+    CRTSpacePoint::~CRTSpacePoint() {}
+
+    double       CRTSpacePoint::X() const { return fPos.X(); }
+    double       CRTSpacePoint::XErr() const { return fPosErr.X(); }
+    double       CRTSpacePoint::Y() const { return fPos.Y(); }
+    double       CRTSpacePoint::YErr() const { return fPosErr.Y(); }
+    double       CRTSpacePoint::Z() const { return fPos.Z(); }
+    double       CRTSpacePoint::ZErr() const { return fPosErr.Z(); }
+    geo::Point_t CRTSpacePoint::Pos() const { return fPos; }
+    geo::Point_t CRTSpacePoint::Err() const { return fPosErr; }
+    double       CRTSpacePoint::PE() const { return fPE; }
+    double       CRTSpacePoint::Time() const { return fTime; }
+    double       CRTSpacePoint::TimeErr() const { return fTimeErr; }
+    bool         CRTSpacePoint::Complete() const { return fComplete; }
+  }
+}
+
+#endif

--- a/sbnobj/SBND/CRT/CRTSpacePoint.hh
+++ b/sbnobj/SBND/CRT/CRTSpacePoint.hh
@@ -1,0 +1,54 @@
+/**
+ * \class CRTSpacePoint
+ *
+ * \brief Product to store the characterisation of a cluster
+ *
+ * \author Henry Lay (h.lay@lancaster.ac.uk)
+ *
+ */
+
+#ifndef SBND_CRTSPACEPOINT_HH
+#define SBND_CRTSPACEPOINT_HH
+
+#include "larcoreobj/SimpleTypesAndConstants/geo_vectors.h"
+
+namespace sbnd::crt {
+
+  class CRTSpacePoint {
+    
+    geo::Point_t fPos;      // position [cm]
+    geo::Point_t fPosErr;   // positional error [cm]
+    double       fPE;       // total PE
+    double       fTime;     // time [ns]
+    double       fTimeErr;  // time error [ns]
+    bool         fComplete; // whether or not the cluster was 3D and contained overlaps
+
+  public:
+
+    CRTSpacePoint();
+    
+    CRTSpacePoint(double _x, double _ex, double _y, double _ey, double _z, double _ez, double _pe, 
+                  double _time, double _etime, bool _complete);
+
+    CRTSpacePoint(geo::Point_t _pos, geo::Point_t _err, double _pe, double _time, double _etime, bool _complete);
+
+    virtual ~CRTSpacePoint();
+
+    double       X() const;
+    double       XErr() const;
+    double       Y() const;
+    double       YErr() const;
+    double       Z() const;
+    double       ZErr() const;
+    geo::Point_t Pos() const;
+    geo::Point_t Err() const;
+    double       PE() const;
+    double       Time() const;
+    double       TimeErr() const;
+    bool         Complete() const;
+
+    CRTSpacePoint& operator= (CRTSpacePoint const&) = default;
+  };
+}
+
+#endif


### PR DESCRIPTION
Following extensive work to rewrite the CRT reconstruction for SBND the PR strategy has been agreed to be a series of PRs against a common branch (`feature/hlay_crt_clustering_base`) for the (inevitably very long) review stage. Please don't use CI tests yet. They will be used on the final PR when the common branch is compared to `develop`. At this stage the individual branches may not each compile on their own. The fully merged branch can be viewed here for completeness [feature/hlay_crt_clustering_merged](https://github.com/SBNSoftware/sbnobj/tree/feature/hlay_crt_clustering_merged).

This PR introduces the new CRTSpacePoint object which represents a characterisation of a CRTCluster.