### PR TITLE
Add CRTTrack object

### DIFF
--- a/sbnobj/SBND/CRT/CRTTrack.cxx
+++ b/sbnobj/SBND/CRT/CRTTrack.cxx
@@ -1,0 +1,60 @@
+#ifndef SBND_CRTTRACK_CXX
+#define SBND_CRTTRACK_CXX
+
+#include "sbnobj/SBND/CRT/CRTTrack.hh"
+
+namespace sbnd {
+
+  namespace crt {
+
+    CRTTrack::CRTTrack()
+      : fPoints  ({})
+      , fTime    (0.)
+      , fTimeErr (0.)
+      , fPE      (0.)
+      , fToF     (0.)
+      , fTaggers ({})
+    {}
+
+    CRTTrack::CRTTrack(const geo::Point_t &_start, const geo::Point_t &_end, const double &_time, const double &_etime,
+                       const double &_pe, const double &_tof, const std::set<CRTTagger> &_taggers)
+      : fPoints  ({_start, _end})
+      , fTime    (_time)
+      , fTimeErr (_etime)
+      , fPE      (_pe)
+      , fToF     (_tof)
+      , fTaggers (_taggers)
+    {}
+
+    CRTTrack::CRTTrack(const std::vector<geo::Point_t> &_points, const double &_time, const double &_etime,
+                       const double &_pe, const double &_tof, const std::set<CRTTagger> &_taggers)
+      : fPoints  (_points)
+      , fTime    (_time)
+      , fTimeErr (_etime)
+      , fPE      (_pe)
+      , fToF     (_tof)
+      , fTaggers (_taggers)
+    {}
+
+    CRTTrack::~CRTTrack() {}
+
+    std::vector<geo::Point_t> CRTTrack::Points() const { return fPoints; }
+    double                    CRTTrack::Time() const {return fTime; }
+    double                    CRTTrack::TimeErr() const { return fTimeErr; }
+    double                    CRTTrack::PE() const { return fPE; }
+    double                    CRTTrack::ToF() const { return fToF; }
+    std::set<CRTTagger>       CRTTrack::Taggers() const { return fTaggers; }
+
+    geo::Point_t  CRTTrack::Start() const { return fPoints.front(); }
+    geo::Point_t  CRTTrack::End() const { return fPoints.back(); }
+    geo::Vector_t CRTTrack::Direction() const { return (End() - Start()).Unit(); }
+    double        CRTTrack::Length() const { return (End() - Start()).R(); }
+    double        CRTTrack::Theta() const { return (End() - Start()).Theta(); }
+    double        CRTTrack::Phi() const { return (End() - Start()).Phi(); }
+    bool          CRTTrack::Triple() const { return fTaggers.size() == 3; }
+
+    bool CRTTrack::UsedTagger(const CRTTagger tagger) const { return fTaggers.count(tagger) == 1; }
+  }
+}
+
+#endif

--- a/sbnobj/SBND/CRT/CRTTrack.hh
+++ b/sbnobj/SBND/CRT/CRTTrack.hh
@@ -1,0 +1,60 @@
+/**
+ * \class CRTTrack
+ *
+ * \brief Product to store a track between CRTSpacePoints
+ *
+ * \author Henry Lay (h.lay@lancaster.ac.uk)
+ *
+ */
+
+#ifndef SBND_CRTTRACK_HH
+#define SBND_CRTTRACK_HH
+
+#include "larcoreobj/SimpleTypesAndConstants/geo_vectors.h"
+#include "sbnobj/SBND/CRT/CRTEnums.hh"
+
+#include <set>
+
+namespace sbnd::crt {
+
+  class CRTTrack {
+    
+    std::vector<geo::Point_t> fPoints;  // the fitted track points at each tagger [cm]
+    double                    fTime;    // average time [ns]
+    double                    fTimeErr; // average time error [ns]
+    double                    fPE;      // total PE
+    double                    fToF;     // time from first space point to last [ns]
+    std::set<CRTTagger>       fTaggers; // which taggers were used to create the track
+
+  public:
+
+    CRTTrack();
+    
+    CRTTrack(const geo::Point_t &_start, const geo::Point_t &_end, const double &_time, const double &_etime,
+             const double &_pe, const double &_tof, const std::set<CRTTagger> &_taggers);
+
+    CRTTrack(const std::vector<geo::Point_t> &_points, const double &_time, const double &_etime,
+             const double &_pe, const double &_tof, const std::set<CRTTagger> &_taggers);
+
+    virtual ~CRTTrack();
+
+    std::vector<geo::Point_t> Points() const;
+    double                    Time() const;
+    double                    TimeErr() const;
+    double                    PE() const;
+    double                    ToF() const;
+    std::set<CRTTagger>       Taggers() const;
+
+    geo::Point_t  Start() const;
+    geo::Point_t  End() const;
+    geo::Vector_t Direction() const;
+    double        Length() const;
+    double        Theta() const;
+    double        Phi() const;
+    bool          Triple() const;
+    
+    bool UsedTagger(const CRTTagger tagger) const;
+  };
+}
+
+#endif


### PR DESCRIPTION
Following extensive work to rewrite the CRT reconstruction for SBND the PR strategy has been agreed to be a series of PRs against a common branch (`feature/hlay_crt_clustering_base`) for the (inevitably very long) review stage. Please don't use CI tests yet. They will be used on the final PR when the common branch is compared to `develop`. At this stage the individual branches may not each compile on their own. The fully merged branch can be viewed here for completeness [feature/hlay_crt_clustering_merged](https://github.com/SBNSoftware/sbnobj/tree/feature/hlay_crt_clustering_merged).

This PR introduces the new CRTTrack object, this differs from the sbn::CRTTrack object as there are many unused variables in that object.