### PR TITLE
move CRTPMTMatching definitions from icaurscode to sbnobj

### DIFF
--- a/sbnobj/Common/CRT/CRTPMTMatching.hh
+++ b/sbnobj/Common/CRT/CRTPMTMatching.hh
@@ -1,0 +1,116 @@
+/**
+ * @file   sbnobj/Common/CRTPMTMatching.hh
+ * @brief  data product to store CRT PMT Matches 
+ * @author Anna Heggestuen (aheggest@colostate.edu) and Francesco Poppi ( poppi@bo.infn.it )
+ * @date   June 1 2023.
+ */
+
+#ifndef CRTPMTMATCHING_hh_
+#define CRTPMTMATCHING_hh_
+
+// C++ includes
+#include <vector>
+#include <limits>
+#include "larcoreobj/SimpleTypesAndConstants/geo_vectors.h"
+
+namespace sbn::crt {
+
+  /// Type of match between a TPC object (e.g. PMT flash) and CRT system.
+  enum class MatchType { /// perhaps it would be better to define these in icaruscode 
+    noMatch           = 0, ///< No CRT match.
+      enTop             = 1, ///< Matched with Top CRT hit before optical flash.
+      enSide            = 2, ///< Matched with Side CRT hit before optical flash.
+      enTop_exSide      = 3, ///< Matched with one Top CRT hit before the optical flash and matched with one Side CRT hit after the optical flash.
+      exTop             = 4, ///< Matched with a Top CRT after the optical flash.
+      exSide            = 5, ///< Matched with a Side CRT after the optical flash.
+      enTop_mult        = 6, ///< Matched with multiple Top CRT hits before the optical flash.
+      enTop_exSide_mult = 7, ///< Matched with multiple Top CRT hits before the optical flash and more then 1 side CRT hits after the optical flash.
+      enBottom          = 8, ///< Matched with bottom CRT hit before the optical flash.
+      exBottom          = 10, ///< Matched with Bottom CRT hit after the optical flash.
+      enTop_exBottom    = 11, ///< Matched with one Top CRT hit before the optical flash and
+      enSide_exBottom   = 12, ///< Matched with one Side CRT hit before the optical flash and matched with one Bottom CRT hit after the optical flash.
+      exTop_enBottom    = 13, ///< Matched with one Bottom CRT hit before the optical flash and matched with one Top CRT hit after the optical flash.
+      exSide_enBottom   = 14, ///< Matched with one Bottom CRT hit before the optical flash and matched with one Side CRT hit after the optical flash.
+      others            = 9  ///< All the other cases.
+      };
+  /// Information about a CRT hit matched with a PMT flash.
+  struct MatchedCRT {
+
+    /// Special value to indicate the lack of information on a time.
+    static constexpr double NoTime = std::numeric_limits<double>::lowest();
+    
+    /// Special value to indicate no information on the hit location.
+    static constexpr int NoLocation = -1;
+
+    geo::Point_t position;           ///< Hit location [cm]
+    double PMTTimeDiff; //= NoTime;     < CRT hit time minus PMT flash time [us] (instead maybe wanna set NoTime vars in 
+    double time;//        = NoTime;     ///< CRT hit time [us]
+    int sys;     //       = NoLocation; ///< CRT subdetector the hit fell into.
+    int region;//         = NoLocation; ///< Region the matched CRT hit fell into.
+  };
+
+  struct CRTPMTMatching{
+    /// Special value to indicate the lack of information on an ID.
+    static constexpr int NoID = std::numeric_limits<int>::min();
+    
+    /// Special value to indicate the lack of information on a counter.
+    static constexpr unsigned int NoCount 
+      = std::numeric_limits<unsigned int>::max();
+
+    /// Special value to indicate the lack of information on a time.
+    static constexpr double NoTime = std::numeric_limits<double>::lowest();
+
+    /// Special value to indicate the lack of information on flash photoelectrons.
+    static constexpr double NoPE = -1.0;
+
+    /// Special value to indicate the lack of information on flash width.
+    static constexpr double NoWidth = -1.0;
+
+
+    int          flashID;//             = NoID;    ///< ID of the optical flash.
+    double       flashTime;//           = NoTime;  ///< Time of the optical flash w.r.t. the global trigger [us]
+    double       flashGateTime;//       = NoTime;  ///< Time of the optical flash w.r.t. the beam gate opening [us]
+    double       firstOpHitPeakTime;//  = NoTime;  ///< Time of the first optical hit peak time w.r.t. the global trigger [us]
+    double       firstOpHitStartTime;// = NoTime;  ///< Time of the first optical hit start time w.r.t. the global trigger [us]
+    bool         flashInGate;//         = false;   ///< Flash within gate or not.
+    bool         flashInBeam ;//        = false;   ///< Flash within the beam window of the gate or not.
+    double       flashPE;//             = -1.0;    ///< Total reconstructed light in the flash [photoelectrons]
+    geo::Point_t flashPosition;                 ///< Flash barycenter coordinates evaluated using ADCs as weights.
+    double       flashYWidth;//         = NoWidth; ///< Flash spread along Y.
+    double       flashZWidth;//         = NoWidth; ///< Flash spread along Z. 
+    MatchType    flashClassification;// = MatchType::noMatch; ///< Classification of the optical flash.
+    std::vector<MatchedCRT> matchedCRTHits;     ///< Matched CRT Hits with the optical flash.
+    unsigned int nTopCRTHitsBefore   = NoCount; ///< Number of Top CRT Hits before the optical flash.
+    unsigned int nTopCRTHitsAfter    = NoCount; ///< Number of Top CRT Hits after the optical flash.
+    unsigned int nSideCRTHitsBefore  = NoCount; ///< Number of Side CRT Hits before the optical flash.
+    unsigned int nSideCRTHitsAfter   = NoCount; ///< Number of Side CRT Hits after the optical flash.
+
+
+
+    /// Returns whether the information in this record is in any way valid.
+    bool isValid() const { return flashID != NoID; }
+
+  };
+
+  /// Additional information about the matching of one flash and one CRT hit.
+  /// 
+  /// Intended as association metadata.
+  struct CRTPMTMatchingInfo {
+
+    enum class Dir { unknown, entering, exiting };
+
+    /// Special value to indicate the lack of information on a time.
+    static constexpr double NoTime = std::numeric_limits<double>::lowest();
+
+    /// Whether CRT hit describes a particle entering the detector of exiting.
+    Dir direction = Dir::unknown;
+    double timeOfFlight = NoTime; ///< CRT hit time minus PMT flash time [us]
+    double distance; ///< Distance between CRT Hit and optical flash centroid [cm]
+
+  }; // CRTPMTMatchingInfo
+
+
+} // namespace sbn::crt
+
+
+#endif 

--- a/sbnobj/Common/CRT/classes.h
+++ b/sbnobj/Common/CRT/classes.h
@@ -17,14 +17,4 @@
 
 namespace{
   sbn::crt::CRTPMTMatchingInfo meta1;
-
-  art::Assns<sbn::crt::CRTHit, recob::OpFlash, sbn::crt::CRTPMTMatchingInfo> assn11;
-  art::Assns<recob::OpFlash, sbn::crt::CRTHit, sbn::crt::CRTPMTMatchingInfo> assn12;
-
-  art::Assns<recob::OpFlash, sbn::crt::CRTPMTMatching> assn21;
-  art::Assns<sbn::crt::CRTPMTMatching, recob::OpFlash> assn22;
-
-  art::Assns<sbn::crt::CRTHit, sbn::crt::CRTPMTMatching> assn31;
-  art::Assns<sbn::crt::CRTPMTMatching, sbn::crt::CRTHit> assn32;
-
 }

--- a/sbnobj/Common/CRT/classes.h
+++ b/sbnobj/Common/CRT/classes.h
@@ -5,10 +5,26 @@
 #include "sbnobj/Common/CRT/CRTHit.hh"
 #include "sbnobj/Common/CRT/CRTTrack.hh"
 #include "lardataobj/AnalysisBase/T0.h"
+#include "lardataobj/RecoBase/OpFlash.h"
 #include "sbnobj/Common/CRT/CRTTzero.hh"
+#include "sbnobj/Common/CRT/CRTPMTMatching.hh"
 #include "sbnobj/Common/CRT/CRTHit_Legacy.hh"
 #include "sbnobj/Common/CRT/CRTTrack_Legacy.hh"
 #include "sbnobj/Common/CRT/CRTTzero_Legacy.hh"
 #include <vector>
 #include <map>
 #include <utility>
+
+namespace{
+  sbn::crt::CRTPMTMatchingInfo meta1;
+
+  art::Assns<sbn::crt::CRTHit, recob::OpFlash, sbn::crt::CRTPMTMatchingInfo> assn11;
+  art::Assns<recob::OpFlash, sbn::crt::CRTHit, sbn::crt::CRTPMTMatchingInfo> assn12;
+
+  art::Assns<recob::OpFlash, sbn::crt::CRTPMTMatching> assn21;
+  art::Assns<sbn::crt::CRTPMTMatching, recob::OpFlash> assn22;
+
+  art::Assns<sbn::crt::CRTHit, sbn::crt::CRTPMTMatching> assn31;
+  art::Assns<sbn::crt::CRTPMTMatching, sbn::crt::CRTHit> assn32;
+
+}

--- a/sbnobj/Common/CRT/classes.h
+++ b/sbnobj/Common/CRT/classes.h
@@ -15,6 +15,4 @@
 #include <map>
 #include <utility>
 
-namespace{
-  sbn::crt::CRTPMTMatchingInfo meta1;
-}
+

--- a/sbnobj/Common/CRT/classes_def.xml
+++ b/sbnobj/Common/CRT/classes_def.xml
@@ -124,4 +124,50 @@
  <class name="art::Assns<icarus::crt::CRTHit, icarus::crt::CRTTzero,    void>"           />
  <class name="art::Wrapper< art::Assns<icarus::crt::CRTHit, icarus::crt::CRTTzero, void> >"           />
 
+ <!-- CRT PMT Matching -->
+ <enum name="sbn::crt::MatchType"/>
+ <class name="sbn::crt::MatchedCRT"/>
+ <class name="vector<sbn::crt::MatchedCRT>"/>
+ <class name="sbn::crt::CRTPMTMatching"/>
+ <class name="std::vector<sbn::crt::CRTPMTMatching>"/>
+ <class name="art::Wrapper<vector<sbn::crt::CRTPMTMatching>>" />
+
+  <!-- associations: sbn::crt::CRTPMTMatching, recob::OpFlash -->
+  <class name="art::Assns<sbn::crt::CRTPMTMatching, recob::OpFlash, void>" />
+  <class name="art::Wrapper<art::Assns<sbn::crt::CRTPMTMatching, recob::OpFlash>>" />
+
+  <class name="art::Assns<recob::OpFlash, sbn::crt::CRTPMTMatching, void>" />
+  <class name="art::Wrapper<art::Assns<recob::OpFlash, sbn::crt::CRTPMTMatching>>" />
+
+  <!-- associations: sbn::crt::CRTPMTMatching, sbn::crt::CRTHit -->
+  <class name="art::Assns<sbn::crt::CRTPMTMatching, sbn::crt::CRTHit, void>" />
+  <class name="art::Wrapper<art::Assns<sbn::crt::CRTPMTMatching, sbn::crt::CRTHit>>" />
+
+  <class name="art::Assns<sbn::crt::CRTHit, sbn::crt::CRTPMTMatching, void>" />
+  <class name="art::Wrapper<art::Assns<sbn::crt::CRTHit, sbn::crt::CRTPMTMatching>>" />
+
+
+  <!-- associations: recob::OpFlash, sbn::crt::CRTHit -->
+  <enum name="sbn::crt::CRTPMTMatchingInfo::Dir"/>
+  <class name="sbn::crt::CRTPMTMatchingInfo"/>
+  <class name="std::vector<sbn::crt::CRTPMTMatchingInfo>"/>
+  <class name="art::Assns<recob::OpFlash,sbn::crt::CRTHit,void>"/>
+  <class name="art::Wrapper<art::Assns<recob::OpFlash,sbn::crt::CRTHit>>"/>
+
+  <!-- associations: recob::OpFlash, sbn::crt::CRTHit, sbn::crt::CRTPMTMatchingInfo-->
+  <class name="art::Assns<recob::OpFlash,sbn::crt::CRTHit,sbn::crt::CRTPMTMatchingInfo>"/>
+  <class name="art::Wrapper<art::Assns<recob::OpFlash,sbn::crt::CRTHit,sbn::crt::CRTPMTMatchingInfo>> "/>
+  
+
+  <!-- associations: sbn::crt::CRTHit, recob::OpFlash, void-->
+  <class name="art::Assns<sbn::crt::CRTHit, recob::OpFlash, void>"/>
+  <class name="art::Wrapper<art::Assns<sbn::crt::CRTHit, recob::OpFlash>>" />
+  
+  <!-- associations: sbn::crt::CRTHit, recob::OpFlash, sbn::crt::CRTPMTMatchingInfo-->
+  <class name="art::Assns<sbn::crt::CRTHit, recob::OpFlash, sbn::crt::CRTPMTMatchingInfo>" />
+  <class name="art::Wrapper<art::Assns<sbn::crt::CRTHit, recob::OpFlash, sbn::crt::CRTPMTMatchingInfo>>" />
+
+  <!--<class name="art::Assns<recob::OpFlash,sbn::crt::CRTHit,sbn::crt::CRTPMTMatchingInfo>"/>
+ <class name="art::Wrapper<art::Assns<recob::OpFlash,sbn::crt::CRTHit,sbn::crt::CRTPMTMatchingInfo> >"/>
+ <class name="art::Wrapper<art::Assns<sbn::crt::CRTHit,recob::OpFlash,sbn::crt::CRTPMTMatchingInfo> >"/>-->
 </lcgdict>


### PR DESCRIPTION
This pull request modifies where the CRTPMTMatching data product introduced in icaruscode v09_75_01 (from pull request https://github.com/SBNSoftware/icaruscode/pull/579) is defined to be in a SBN common area (sbnobj) (`icarus::crt::CRTPMTMatching` -> `sbn::crt::CRTPMTMatching`) so that the matching variables can be read in to the CAFs.

This is part of a PR pair that moves CRTPMTMatching definitions from `icaruscode/IcarusObj` to `sbnobj/Common`: 
* icaurscode PR #[594](https://github.com/SBNSoftware/icaruscode/pull/594) 
* sbnobj PR #[86](https://github.com/SBNSoftware/sbnobj/pull/86)