### PR TITLE
Added dictionary for art wrapper to trigger data product

### DIFF
--- a/sbnobj/Common/Trigger/classes_def.xml
+++ b/sbnobj/Common/Trigger/classes_def.xml
@@ -35,5 +35,6 @@
     <class name="art::Ptr<sbn::ExtraTriggerInfo>"/>
     <class name="art::Wrapper<sbn::ExtraTriggerInfo>"/>
     <class name="std::vector<sbn::ExtraTriggerInfo>"/>
+    <class name="art::Wrapper<std::vector<sbn::ExtraTriggerInfo>>"/>
 
   </lcgdict>


### PR DESCRIPTION
The dictionary was missing.
Thanks to @jzennamo for noticing. As ~punishment~ reward, he and the one who pointed him to me are nominated reviewers.

Note that this is a GitHub PR (with a `faeture` branch, apparently, because my straem of characters sometimes does that).
