### PR TITLE
OpT0 CRUMBS

### DIFF
--- a/sbnobj/Common/Reco/CRUMBSResult.cc
+++ b/sbnobj/Common/Reco/CRUMBSResult.cc
@@ -4,8 +4,8 @@ sbn::CRUMBSResult::CRUMBSResult(float score, float ccnumuscore, float ccnuescore
 				float tpc_CRFracHitsInLongestTrack, float tpc_CRLongestTrackDeflection, float tpc_CRLongestTrackDirY,
 				int tpc_CRNHitsMax, float tpc_NuEigenRatioInSphere, int tpc_NuNFinalStatePfos, int tpc_NuNHitsTotal,
 				int tpc_NuNSpacePointsInSphere, float tpc_NuVertexY, float tpc_NuWeightedDirZ, float tpc_StoppingChi2CosmicRatio,
-				float pds_FMTotalScore, float pds_FMPE, float pds_FMTime, float crt_TrackScore, float crt_HitScore,
-				float crt_TrackTime, float crt_HitTime)
+				float pds_FMTotalScore, float pds_FMPE, float pds_FMTime, float pds_OpT0Score, float pds_OpT0MeasuredPE,
+				float crt_TrackScore, float crt_HitScore, float crt_TrackTime, float crt_HitTime)
   : score(score)
   , ccnumuscore(ccnumuscore)
   , ccnuescore(ccnuescore)
@@ -26,6 +26,8 @@ sbn::CRUMBSResult::CRUMBSResult(float score, float ccnumuscore, float ccnuescore
   , pds_FMTotalScore(pds_FMTotalScore)
   , pds_FMPE(pds_FMPE)
   , pds_FMTime(pds_FMTime)
+  , pds_OpT0Score(pds_OpT0Score)
+  , pds_OpT0MeasuredPE(pds_OpT0MeasuredPE)
   , crt_TrackScore(crt_TrackScore)
   , crt_HitScore(crt_HitScore)
   , crt_TrackTime(crt_TrackTime)

--- a/sbnobj/Common/Reco/CRUMBSResult.cc
+++ b/sbnobj/Common/Reco/CRUMBSResult.cc
@@ -5,7 +5,7 @@ sbn::CRUMBSResult::CRUMBSResult(float score, float ccnumuscore, float ccnuescore
 				int tpc_CRNHitsMax, float tpc_NuEigenRatioInSphere, int tpc_NuNFinalStatePfos, int tpc_NuNHitsTotal,
 				int tpc_NuNSpacePointsInSphere, float tpc_NuVertexY, float tpc_NuWeightedDirZ, float tpc_StoppingChi2CosmicRatio,
 				float pds_FMTotalScore, float pds_FMPE, float pds_FMTime, float pds_OpT0Score, float pds_OpT0MeasuredPE,
-				float crt_TrackScore, float crt_HitScore, float crt_TrackTime, float crt_HitTime)
+				float crt_TrackScore, float crt_SPScore, float crt_TrackTime, float crt_SPTime)
   : score(score)
   , ccnumuscore(ccnumuscore)
   , ccnuescore(ccnuescore)
@@ -29,9 +29,9 @@ sbn::CRUMBSResult::CRUMBSResult(float score, float ccnumuscore, float ccnuescore
   , pds_OpT0Score(pds_OpT0Score)
   , pds_OpT0MeasuredPE(pds_OpT0MeasuredPE)
   , crt_TrackScore(crt_TrackScore)
-  , crt_HitScore(crt_HitScore)
+  , crt_SPScore(crt_SPScore)
   , crt_TrackTime(crt_TrackTime)
-  , crt_HitTime(crt_HitTime)
+  , crt_SPTime(crt_SPTime)
 {
 }
 

--- a/sbnobj/Common/Reco/CRUMBSResult.h
+++ b/sbnobj/Common/Reco/CRUMBSResult.h
@@ -18,8 +18,8 @@ namespace sbn {
 		 int tpc_NuNFinalStatePfos = default_int, int tpc_NuNHitsTotal = default_int, int tpc_NuNSpacePointsInSphere = default_int, 
 		 float tpc_NuVertexY = default_float, float tpc_NuWeightedDirZ = default_float, float tpc_StoppingChi2CosmicRatio = default_float, 
 		 float pds_FMTotalScore = default_float, float pds_FMPE = default_float, float pds_FMTime = default_float, float pds_OpT0Score = default_float,
-		 float pds_OpT0MeasuredPE = default_float, float crt_TrackScore = default_float, float crt_HitScore = default_float, float crt_TrackTime = default_float,
-		 float crt_HitTime = default_float);
+		 float pds_OpT0MeasuredPE = default_float, float crt_TrackScore = default_float, float crt_SPScore = default_float, float crt_TrackTime = default_float,
+		 float crt_SPTime = default_float);
     
     float score;                         //!< CRUMBS result, for inclusive neutrino signal
     float ccnumuscore;                   //!< CRUMBS result, for CCNuMu signal
@@ -44,9 +44,9 @@ namespace sbn {
     float pds_OpT0Score;                 //!< the agreement score from the OpT0 falsh matcher
     float pds_OpT0MeasuredPE;            //!< the PE of the reconstructed flash matched by OpT0
     float crt_TrackScore;                //!< a combination of the DCA and angle between the best matched TPC & CRT tracks
-    float crt_HitScore;                  //!< the best distance from an extrapolated TPC track to a CRT hit [cm]
+    float crt_SPScore;                   //!< the best distance from an extrapolated TPC track to a CRT spacepoint [cm]
     float crt_TrackTime;                 //!< the time associated with the matched CRT track [us]
-    float crt_HitTime;                   //!< the time associated with the matched CRT hit [us]
+    float crt_SPTime;                    //!< the time associated with the matched CRT spacepoint [us]
   };
 }
 

--- a/sbnobj/Common/Reco/CRUMBSResult.h
+++ b/sbnobj/Common/Reco/CRUMBSResult.h
@@ -17,8 +17,9 @@ namespace sbn {
 		 float tpc_CRLongestTrackDirY = default_float, int tpc_CRNHitsMax = default_int, float tpc_NuEigenRatioInSphere = default_float, 
 		 int tpc_NuNFinalStatePfos = default_int, int tpc_NuNHitsTotal = default_int, int tpc_NuNSpacePointsInSphere = default_int, 
 		 float tpc_NuVertexY = default_float, float tpc_NuWeightedDirZ = default_float, float tpc_StoppingChi2CosmicRatio = default_float, 
-		 float pds_FMTotalScore = default_float, float pds_FMPE = default_float, float pds_FMTime = default_float, float crt_TrackScore = default_float, 
-		 float crt_HitScore = default_float, float crt_TrackTime = default_float, float crt_HitTime = default_float);
+		 float pds_FMTotalScore = default_float, float pds_FMPE = default_float, float pds_FMTime = default_float, float pds_OpT0Score = default_float,
+		 float pds_OpT0MeasuredPE = default_float, float crt_TrackScore = default_float, float crt_HitScore = default_float, float crt_TrackTime = default_float,
+		 float crt_HitTime = default_float);
     
     float score;                         //!< CRUMBS result, for inclusive neutrino signal
     float ccnumuscore;                   //!< CRUMBS result, for CCNuMu signal
@@ -40,6 +41,8 @@ namespace sbn {
     float pds_FMTotalScore;              //!< the total flash match score
     float pds_FMPE;                      //!< the total number of photoelectrons in the associated flash
     float pds_FMTime;                    //!< the time associated with the flash [us]
+    float pds_OpT0Score;                 //!< the agreement score from the OpT0 falsh matcher
+    float pds_OpT0MeasuredPE;            //!< the PE of the reconstructed flash matched by OpT0
     float crt_TrackScore;                //!< a combination of the DCA and angle between the best matched TPC & CRT tracks
     float crt_HitScore;                  //!< the best distance from an extrapolated TPC track to a CRT hit [cm]
     float crt_TrackTime;                 //!< the time associated with the matched CRT track [us]

--- a/sbnobj/Common/Reco/classes_def.xml
+++ b/sbnobj/Common/Reco/classes_def.xml
@@ -54,7 +54,8 @@
   <class name="art::Assns<sbn::SimpleFlashMatch,recob::PFParticle, void>" />
   <class name="art::Wrapper<art::Assns<sbn::SimpleFlashMatch, recob::PFParticle, void> >" />
 
-  <class name="sbn::CRUMBSResult" ClassVersion="11">
+  <class name="sbn::CRUMBSResult" ClassVersion="12">
+   <version ClassVersion="12" checksum="526337898"/>
    <version ClassVersion="11" checksum="2038758639"/>
    <version ClassVersion="10" checksum="1001500335"/>
   </class>

--- a/sbnobj/Common/Reco/classes_def.xml
+++ b/sbnobj/Common/Reco/classes_def.xml
@@ -54,7 +54,8 @@
   <class name="art::Assns<sbn::SimpleFlashMatch,recob::PFParticle, void>" />
   <class name="art::Wrapper<art::Assns<sbn::SimpleFlashMatch, recob::PFParticle, void> >" />
 
-  <class name="sbn::CRUMBSResult" ClassVersion="12">
+  <class name="sbn::CRUMBSResult" ClassVersion="13">
+   <version ClassVersion="13" checksum="2221682896"/>
    <version ClassVersion="12" checksum="526337898"/>
    <version ClassVersion="11" checksum="2038758639"/>
    <version ClassVersion="10" checksum="1001500335"/>


### PR DESCRIPTION
Simply adds the new OpT0 CRUMBS variables to the object, main PR is SBNSoftware/sbncode#413

~_This PR requires the (approved) CRT Clustering PRs to be merged first, until then the diff will look huge, it's not._~