### PR TITLE
Add true trajectory points to truth information

### DIFF
--- a/sbnobj/Common/Calibration/TrackCaloSkimmerObj.h
+++ b/sbnobj/Common/Calibration/TrackCaloSkimmerObj.h
@@ -206,6 +206,9 @@ namespace sbn {
     std::vector<TrueHit> truehits1; //!< List of True "hits" of this particle on Plane 1
     std::vector<TrueHit> truehits2; //!< List of True "hits" of this particle on Plane 2
 
+    std::vector<Vector3D> traj; //!< True trajectory of particle
+    std::vector<Vector3D> traj_sce; //!< True trajectory of particle, deflected by space charge
+
     TrueParticle():
       plane0VisE(std::numeric_limits<float>::signaling_NaN()),
       plane1VisE(std::numeric_limits<float>::signaling_NaN()),

--- a/sbnobj/Common/Calibration/classes_def.xml
+++ b/sbnobj/Common/Calibration/classes_def.xml
@@ -5,7 +5,8 @@
   <class name="sbn::TrackTruth" ClassVersion="10">
    <version ClassVersion="10" checksum="2749399767"/>
   </class>
-  <class name="sbn::TrueParticle" ClassVersion="11">
+  <class name="sbn::TrueParticle" ClassVersion="12">
+   <version ClassVersion="12" checksum="3355992085"/>
    <version ClassVersion="11" checksum="855399631"/>
    <version ClassVersion="10" checksum="2150513055"/>
   </class>


### PR DESCRIPTION
Cherry-picking in what I think are the relevant commits from Gray's feature branch used in the reprocessing.

Not sure if this is necessary if we don't include the calibration ntuple change in icaruscode but it should be there as of now.