### PR TITLE
Adding trigger information for ICARUS

### DIFF
--- a/sbnobj/Common/Trigger/BeamBits.h
+++ b/sbnobj/Common/Trigger/BeamBits.h
@@ -184,7 +184,7 @@ namespace sbn {
     std::string bitName(triggerType bit);
     /// Returns a mnemonic short name for the trigger window mode.
     std::string bitName(triggerWindowMode bit);
-    /// Returns a mnemonic short name for the trigger window mode.
+    /// Returns a mnemonic short name for the gate type.
     std::string bitName(gateSelection bit);
 
     /// @}

--- a/sbnobj/Common/Trigger/BeamBits.h
+++ b/sbnobj/Common/Trigger/BeamBits.h
@@ -137,8 +137,11 @@ namespace sbn {
     
     /// Trigger window mode
     enum class triggerWindowMode: unsigned int {
-      Separated,    ///< Separated, non-overlapping contigous window
-      Overlapping,  ///< Overlaping windows
+      Separated,             ///< Separated, non-overlapping contiguous window.
+      Overlapping,           ///< Overlapping windows.
+      SeparatedPlusAdders,   ///< OR of `Separated` and `Adders`.
+      OverlappingPlusAdders, ///< OR of `Overlapping` and `Adders`.
+      Adders,                ///< Trigger from adders.
       //==> add here if more are needed <==
       NBits     ///< Number of Bits currently supported
     };
@@ -315,8 +318,11 @@ inline std::string sbn::bits::bitName(triggerWindowMode bit) {
 
   using namespace std::string_literals;
   switch (bit) {
-    case sbn::bits::triggerWindowMode::Separated:    return "Separated Window"s;
-    case sbn::bits::triggerWindowMode::Overlapping:  return "Overlapping Window"s;
+    case sbn::bits::triggerWindowMode::Separated:             return "Separated Window"s;
+    case sbn::bits::triggerWindowMode::Overlapping:           return "Overlapping Window"s;
+    case sbn::bits::triggerWindowMode::SeparatedPlusAdders:   return "Separated Both"s;
+    case sbn::bits::triggerWindowMode::OverlappingPlusAdders: return "Overlapping Both"s;
+    case sbn::bits::triggerWindowMode::Adders:                return "Adders"s;
     case sbn::bits::triggerWindowMode::NBits:    return "<invalid>"s;
   } // switch
   throw std::runtime_error("sbn::bits::bitName(triggerWindowMode{ "s

--- a/sbnobj/Common/Trigger/BeamBits.h
+++ b/sbnobj/Common/Trigger/BeamBits.h
@@ -124,6 +124,17 @@ namespace sbn {
     /// Type of mask with `triggerLocation` bits.
     using triggerLocationMask = mask_t<triggerLocation>;
 
+    /// Type(s) of trigger logic being satisfied.
+    enum class triggerLogic: unsigned int {
+      PMTAnalogSum,    ///< Discriminated PMT signal sum above threshold.
+      PMTPairMajority, ///< Minimum number of discriminated PMT above threshold.
+      // ==> add here if more are needed <==
+      NBits    ///< Number of bits currently supported.
+    }; // triggerLocation
+
+    /// Type of mask with `triggerLogic` bits.
+    using triggerLogicMask = mask_t<triggerLogic>;
+
     /// Type representing the type(s) of this trigger.
     enum class triggerType: unsigned int {
       Majority,    ///< A minimum number of close-by PMT pairs above threshold was reached.
@@ -180,6 +191,8 @@ namespace sbn {
     std::string bitName(triggerSource bit);
     /// Returns a mnemonic short name of the trigger location.
     std::string bitName(triggerLocation bit);
+    /// Returns a mnemonic short name of the trigger logic.
+    std::string bitName(triggerLogic bit);
     /// Returns a mnemonic short name of the trigger type.
     std::string bitName(triggerType bit);
     /// Returns a mnemonic short name for the trigger window mode.
@@ -196,6 +209,8 @@ namespace sbn {
   using bits::triggerSourceMask;
   using bits::triggerType;
   using bits::triggerTypeMask;
+  using bits::triggerLogic;
+  using bits::triggerLogicMask;
   using bits::triggerLocation;
   using bits::triggerLocationMask;
   using bits::triggerWindowMode;
@@ -283,8 +298,8 @@ inline std::string sbn::bits::bitName(triggerSource bit) {
     + std::to_string(value(bit)) + " }): unknown bit"s);
 } // sbn::bitName()
 
-// -----------------------------------------------------------------------------
 
+// -----------------------------------------------------------------------------
 inline std::string sbn::bits::bitName(triggerLocation bit) {
 
   using namespace std::string_literals;
@@ -301,6 +316,21 @@ inline std::string sbn::bits::bitName(triggerLocation bit) {
     + std::to_string(value(bit)) + " }): unknown bit"s);
 } // sbn::bitName(triggerLocation)
 
+
+// -----------------------------------------------------------------------------
+inline std::string sbn::bits::bitName(triggerLogic bit) {
+
+  using namespace std::string_literals;
+  switch (bit) {
+    case triggerLogic::PMTPairMajority: return "PMT pair majority"s;
+    case triggerLogic::PMTAnalogSum:    return "PMT analog sum"s;
+    case triggerLogic::NBits:           return "<invalid>"s;
+  } // switch
+  throw std::runtime_error("sbn::bits::bitName(triggerLogic{ "s
+    + std::to_string(value(bit)) + " }): unknown bit"s);
+} // sbn::bitName(triggerLogic)
+
+
 // -----------------------------------------------------------------------------
 inline std::string sbn::bits::bitName(triggerType bit) {
 
@@ -314,6 +344,8 @@ inline std::string sbn::bits::bitName(triggerType bit) {
     + std::to_string(value(bit)) + " }): unknown bit"s);
 } // sbn::bitName(triggerType)
 
+
+// -----------------------------------------------------------------------------
 inline std::string sbn::bits::bitName(triggerWindowMode bit) {
 
   using namespace std::string_literals;
@@ -330,6 +362,7 @@ inline std::string sbn::bits::bitName(triggerWindowMode bit) {
 } // triggerWindowMode
 
 
+// -----------------------------------------------------------------------------
 inline std::string sbn::bits::bitName(gateSelection bit) {
 
   using namespace std::string_literals;
@@ -361,6 +394,7 @@ inline std::string sbn::bits::bitName(gateSelection bit) {
 } // sbn::bitName()
 
 
+// -----------------------------------------------------------------------------
 namespace icarus::trigger {
 
   using triggerLocation = sbn::triggerLocation;

--- a/sbnobj/Common/Trigger/ExtraTriggerInfo.cxx
+++ b/sbnobj/Common/Trigger/ExtraTriggerInfo.cxx
@@ -217,11 +217,11 @@ std::ostream& sbn::operator<< (std::ostream& out, ExtraTriggerInfo const& info)
       << "\n  east wall:  "
       << dumpLVDSmask(cryo.LVDSstatus[ExtraTriggerInfo::EastPMTwall])
       << ", sectors: "
-      << dumpBits(cryo.SectorStatus[ExtraTriggerInfo::EastPMTwall], 6)
+      << dumpBits(cryo.sectorStatus[ExtraTriggerInfo::EastPMTwall], 6)
       << "\n  west wall:  "
       << dumpLVDSmask(cryo.LVDSstatus[ExtraTriggerInfo::WestPMTwall])
       << ", sectors: "
-      << dumpBits(cryo.SectorStatus[ExtraTriggerInfo::WestPMTwall], 6)
+      << dumpBits(cryo.sectorStatus[ExtraTriggerInfo::WestPMTwall], 6)
       ;
   }
 
@@ -235,11 +235,11 @@ std::ostream& sbn::operator<< (std::ostream& out, ExtraTriggerInfo const& info)
       << "\n  east wall:  "
       << dumpLVDSmask(cryo.LVDSstatus[ExtraTriggerInfo::EastPMTwall])
       << ", sectors: "
-      << dumpBits(cryo.SectorStatus[ExtraTriggerInfo::EastPMTwall], 6)
+      << dumpBits(cryo.sectorStatus[ExtraTriggerInfo::EastPMTwall], 6)
       << "\n  west wall:  "
       << dumpLVDSmask(cryo.LVDSstatus[ExtraTriggerInfo::WestPMTwall])
       << ", sectors: "
-      << dumpBits(cryo.SectorStatus[ExtraTriggerInfo::WestPMTwall], 6)
+      << dumpBits(cryo.sectorStatus[ExtraTriggerInfo::WestPMTwall], 6)
       ;
   }
   

--- a/sbnobj/Common/Trigger/ExtraTriggerInfo.cxx
+++ b/sbnobj/Common/Trigger/ExtraTriggerInfo.cxx
@@ -211,8 +211,14 @@ std::ostream& sbn::operator<< (std::ostream& out, ExtraTriggerInfo const& info)
       << info.cryostats[ExtraTriggerInfo::EastCryostat].triggerCount
       << " triggers";
   if (auto const& cryo = info.cryostats[ExtraTriggerInfo::EastCryostat];
-      cryo.hasLVDS()
-      ) {
+      cryo.hasAnyActivity()
+  ) {
+    out << "\n  trigger logic: ";
+    if (cryo.triggerLogicBits) {
+      for (std::string const& bitName: names(cryo.triggerLogic()))
+        out << " " << bitName;
+    }
+    else out << " none!";
     out
       << "\n  east wall:  "
       << dumpLVDSmask(cryo.LVDSstatus[ExtraTriggerInfo::EastPMTwall])
@@ -229,8 +235,14 @@ std::ostream& sbn::operator<< (std::ostream& out, ExtraTriggerInfo const& info)
       << info.cryostats[ExtraTriggerInfo::WestCryostat].triggerCount
       << " triggers";
   if (auto const& cryo = info.cryostats[ExtraTriggerInfo::WestCryostat];
-      cryo.hasLVDS()
-      ) {
+      cryo.hasAnyActivity()
+  ) {
+    out << "\n  trigger logic: ";
+    if (cryo.triggerLogicBits) {
+      for (std::string const& bitName: names(cryo.triggerLogic()))
+        out << " * " << bitName;
+    }
+    else out << " none!";
     out
       << "\n  east wall:  "
       << dumpLVDSmask(cryo.LVDSstatus[ExtraTriggerInfo::EastPMTwall])

--- a/sbnobj/Common/Trigger/ExtraTriggerInfo.h
+++ b/sbnobj/Common/Trigger/ExtraTriggerInfo.h
@@ -238,7 +238,7 @@ struct sbn::ExtraTriggerInfo {
      * 
      * The remaining 10 bits are reserved for future use.
      */
-    std::array<std::uint16_t, MaxWalls> SectorStatus { 0U, 0U };
+    std::array<std::uint16_t, MaxWalls> sectorStatus { 0U, 0U };
     
     /// Returns whether there is some recorded LVDS activity.
     constexpr bool hasLVDS() const;
@@ -254,7 +254,7 @@ struct sbn::ExtraTriggerInfo {
   
   /// Bits for the trigger location (see `triggerLocation()`).
   unsigned int triggerLocationBits { 0U };
-  //sbn::triggerLocation triggerLocationBits { sbn::triggerSource::NBits  }
+  
   /// Status of each LVDS channel in each PMT wall at trigger time.
   std::array<CryostatInfo, MaxCryostats> cryostats;
   
@@ -288,7 +288,7 @@ struct sbn::ExtraTriggerInfo {
   /// Returns sector states on a PMT `wall` of the specified `cryostat`.
   /// @throws std::out_of_range if invalid `cryostat` or `wall`
   std::uint16_t SectorInfo(std::size_t cryostat, std::size_t wall) const
-    { return cryostatInfo(cryostat).SectorStatus.at(wall); }
+    { return cryostatInfo(cryostat).sectorStatus.at(wall); }
   
   /// @}
   // --- END ---- Trigger topology ---------------------------------------------
@@ -341,7 +341,7 @@ inline constexpr bool sbn::ExtraTriggerInfo::CryostatInfo::hasLVDS() const {
 inline constexpr bool sbn::ExtraTriggerInfo::CryostatInfo::hasSectors() const {
   // C++20:
   //  return std::ranges::any_of(SectorStatus, std::identity{});
-  for (std::uint64_t bits: SectorStatus) if (bits) return true;
+  for (std::uint64_t bits: sectorStatus) if (bits) return true;
   return false;
 } // sbn::ExtraTriggerInfo::CryostatInfo::hasSectors()
 

--- a/sbnobj/Common/Trigger/ExtraTriggerInfo.h
+++ b/sbnobj/Common/Trigger/ExtraTriggerInfo.h
@@ -243,10 +243,16 @@ struct sbn::ExtraTriggerInfo {
     /// Returns whether there is some recorded LVDS activity.
     constexpr bool hasLVDS() const;
     
+    /// Returns whether there is some recorded sector activity.
+    constexpr bool hasSectors() const;
+    
+    /// Returns whether there is some recorded activity (LVDS or sector).
+    constexpr bool hasAnyActivity() const;
+    
   }; // CryostatInfo
   
   
-  /// Bits for the trigger location (@see `triggerLocation()`).
+  /// Bits for the trigger location (see `triggerLocation()`).
   unsigned int triggerLocationBits { 0U };
   //sbn::triggerLocation triggerLocationBits { sbn::triggerSource::NBits  }
   /// Status of each LVDS channel in each PMT wall at trigger time.
@@ -321,16 +327,34 @@ namespace sbn {
   std::ostream& operator<< (std::ostream& out, ExtraTriggerInfo const& info);
 }
 
-// -----------------------------------------------------------------------------
 
-constexpr bool sbn::ExtraTriggerInfo::CryostatInfo::hasLVDS() const {
+// -----------------------------------------------------------------------------
+inline constexpr bool sbn::ExtraTriggerInfo::CryostatInfo::hasLVDS() const {
   // C++20:
-  //  return std::ranges::any_of(LVDSstatus, std::identity{});   
+  //  return std::ranges::any_of(LVDSstatus, std::identity{});
   for (std::uint64_t bits: LVDSstatus) if (bits) return true;
   return false;
-} // sbn::ExtraTriggerInfo::CryostatInfo::empty()
+} // sbn::ExtraTriggerInfo::CryostatInfo::hasLVDS()
 
 
+// -----------------------------------------------------------------------------
+inline constexpr bool sbn::ExtraTriggerInfo::CryostatInfo::hasSectors() const {
+  // C++20:
+  //  return std::ranges::any_of(SectorStatus, std::identity{});
+  for (std::uint64_t bits: SectorStatus) if (bits) return true;
+  return false;
+} // sbn::ExtraTriggerInfo::CryostatInfo::hasSectors()
+
+
+// -----------------------------------------------------------------------------
+inline constexpr bool sbn::ExtraTriggerInfo::CryostatInfo::hasAnyActivity()
+  const
+{
+  return hasLVDS() || hasSectors();
+} // sbn::ExtraTriggerInfo::CryostatInfo::hasAnyActivity()
+
+
+// -----------------------------------------------------------------------------
 
 
 #endif // SBNOBJ_COMMON_TRIGGER_EXTRATRIGGERINFO_H

--- a/sbnobj/Common/Trigger/ExtraTriggerInfo.h
+++ b/sbnobj/Common/Trigger/ExtraTriggerInfo.h
@@ -240,6 +240,27 @@ struct sbn::ExtraTriggerInfo {
      */
     std::array<std::uint16_t, MaxWalls> sectorStatus { 0U, 0U };
     
+    /// The type of logic that fired the first trigger in this cryostat.
+    /// @see sbn::bits::triggerLogicMask
+    unsigned int triggerLogicBits { 0U };
+    
+    /**
+     * @brief Returns the type of logic satisfied by the trigger.
+     * 
+     * The returned value is a mask of `sbn::bits::triggerLogic` bits.
+     * To test the state of a bit, it needs to be converted into a mask, e.g.:
+     * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+     * bool isFromAdders
+     *   = extraTriggerInfo.triggerLogic() & mask(sbn::triggerLogic::Adders);
+     * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     * 
+     * Note that one trigger may have satisfied multiple logics within a time
+     * close enough that the trigger is considered fired by all of them.
+     * The "overlap" criterium is decided by the hardware.
+     */
+    sbn::bits::triggerLogicMask triggerLogic() const
+      { return { triggerLogicBits }; }
+    
     /// Returns whether there is some recorded LVDS activity.
     constexpr bool hasLVDS() const;
     

--- a/sbnobj/Common/Trigger/classes_def.xml
+++ b/sbnobj/Common/Trigger/classes_def.xml
@@ -27,7 +27,8 @@
     <enum name="sbn::bits::triggerSource" ClassVersion="10" />
     <enum name="sbn::bits::triggerLocation" ClassVersion="10" />
     <enum name="sbn::bits::triggerType" ClassVersion="10" />
-    <class name="sbn::ExtraTriggerInfo::CryostatInfo" ClassVersion="11" >
+    <class name="sbn::ExtraTriggerInfo::CryostatInfo" ClassVersion="12" >
+     <version ClassVersion="12" checksum="804951501"/>
      <version ClassVersion="11" checksum="3455337645"/>
      <version ClassVersion="10" checksum="313789291"/>
     </class>

--- a/sbnobj/Common/Trigger/classes_def.xml
+++ b/sbnobj/Common/Trigger/classes_def.xml
@@ -27,7 +27,8 @@
     <enum name="sbn::bits::triggerSource" ClassVersion="10" />
     <enum name="sbn::bits::triggerLocation" ClassVersion="10" />
     <enum name="sbn::bits::triggerType" ClassVersion="10" />
-    <class name="sbn::ExtraTriggerInfo::CryostatInfo" ClassVersion="12" >
+    <class name="sbn::ExtraTriggerInfo::CryostatInfo" ClassVersion="13" >
+     <version ClassVersion="13" checksum="2956313925"/>
      <version ClassVersion="12" checksum="804951501"/>
      <version ClassVersion="11" checksum="3455337645"/>
      <version ClassVersion="10" checksum="313789291"/>


### PR DESCRIPTION
ICARUS is introducing a complementary trigger based on analogue sum of PMT signals.
This request extends `sbn::ExtraTriggerInfo` to accommodate for this new trigger:
* additional bits (`sectorStatus`) describe the primitive elements of a trigger based on the detector sector (as opposed to the `LVDSstatus` one which refers to specific PMT channels) -- and yes, it should have been `state` instead of `status` but that train has left some time ago;
* an additional flag to state which logic fired the trigger on each cryostat; so far it can be an adder-like value and a majority-like value, or both;
* additional values in the window mode configuration, now supporting the adder triggers in conjunction with the other modes or alone.

These objects have been filled to accommodate ICARUS trigger settings but they may still be suitable for SBND, at least in general terms.
Pulling for review:
* @jzettle: maintainer of the ICARUS trigger board reader and decoding software;
* @mstancar: because I don't have nearly as much interaction with SBND trigger development and I don't know exactly who is the best SBND person for the software part of it (@pgreen135 maybe?); @mstancar should feel free to unload this to somebody else as needed.

This is a necessary prerequisite for the update of ICARUS trigger decoder for Run3, which will be subject of another `icrauscode` PR soon. But I am starting to roll the ball with this one in the meanwhile.