### PR TITLE
sbn::ExtraTriggerInfo: added cryostat trigger information

### DIFF
--- a/sbnobj/Common/Trigger/ExtraTriggerInfo.cxx
+++ b/sbnobj/Common/Trigger/ExtraTriggerInfo.cxx
@@ -205,58 +205,44 @@ std::ostream& sbn::operator<< (std::ostream& out, ExtraTriggerInfo const& info)
   if (info.triggerLocationBits != 0) {
     out << "\nLocation(s) of trigger:";
     for (std::string const& bitName: names(info.triggerLocation()))
-      out << " " << bitName;
+      out << "  * " << bitName;
   }
-  out << "\nEast cryostat: "
-      << info.cryostats[ExtraTriggerInfo::EastCryostat].triggerCount
-      << " triggers";
-  if (auto const& cryo = info.cryostats[ExtraTriggerInfo::EastCryostat];
-      cryo.hasAnyActivity()
-  ) {
-    out << "\n  trigger logic: ";
-    if (cryo.triggerLogicBits) {
-      for (std::string const& bitName: names(cryo.triggerLogic()))
-        out << " " << bitName;
-    }
-    else out << " none!";
-    out
-      << "\n  east wall:  "
-      << dumpLVDSmask(cryo.LVDSstatus[ExtraTriggerInfo::EastPMTwall])
-      << ", sectors: "
-      << dumpBits(cryo.sectorStatus[ExtraTriggerInfo::EastPMTwall], 6)
-      << "\n  west wall:  "
-      << dumpLVDSmask(cryo.LVDSstatus[ExtraTriggerInfo::WestPMTwall])
-      << ", sectors: "
-      << dumpBits(cryo.sectorStatus[ExtraTriggerInfo::WestPMTwall], 6)
-      ;
-  }
-
-  out << "\nWest cryostat: "
-      << info.cryostats[ExtraTriggerInfo::WestCryostat].triggerCount
-      << " triggers";
-  if (auto const& cryo = info.cryostats[ExtraTriggerInfo::WestCryostat];
-      cryo.hasAnyActivity()
-  ) {
-    out << "\n  trigger logic: ";
-    if (cryo.triggerLogicBits) {
-      for (std::string const& bitName: names(cryo.triggerLogic()))
-        out << " * " << bitName;
-    }
-    else out << " none!";
-    out
-      << "\n  east wall:  "
-      << dumpLVDSmask(cryo.LVDSstatus[ExtraTriggerInfo::EastPMTwall])
-      << ", sectors: "
-      << dumpBits(cryo.sectorStatus[ExtraTriggerInfo::EastPMTwall], 6)
-      << "\n  west wall:  "
-      << dumpLVDSmask(cryo.LVDSstatus[ExtraTriggerInfo::WestPMTwall])
-      << ", sectors: "
-      << dumpBits(cryo.sectorStatus[ExtraTriggerInfo::WestPMTwall], 6)
-      ;
-  }
+  
+  out << "\nWest cryostat: " << info.cryostats[ExtraTriggerInfo::WestCryostat];
+  out << "\nEast cryostat: " << info.cryostats[ExtraTriggerInfo::EastCryostat];
   
   return out;
 } // sbn::operator<< (ExtraTriggerInfo)
+
+
+
+// -----------------------------------------------------------------------------
+std::ostream& sbn::operator<<
+  (std::ostream& out, sbn::ExtraTriggerInfo::CryostatInfo const& cryo)
+{
+  out << cryo.triggerCount << " triggers";
+  if (cryo.hasTrigger())
+    out << ", the first one " << cryo.beamToTrigger << " ns after gate";
+  if (cryo.hasAnyActivity()) {
+    out << "\n  trigger logic: ";
+    if (cryo.triggerLogicBits) {
+      for (std::string const& bitName: names(cryo.triggerLogic()))
+        out << "  * " << bitName;
+    }
+    else out << " none!";
+    out
+      << "\n  east wall:  "
+      << dumpLVDSmask(cryo.LVDSstatus[ExtraTriggerInfo::EastPMTwall])
+      << ", sectors: "
+      << dumpBits(cryo.sectorStatus[ExtraTriggerInfo::EastPMTwall], 6)
+      << "\n  west wall:  "
+      << dumpLVDSmask(cryo.LVDSstatus[ExtraTriggerInfo::WestPMTwall])
+      << ", sectors: "
+      << dumpBits(cryo.sectorStatus[ExtraTriggerInfo::WestPMTwall], 6)
+      ;
+  }
+  return out;
+} // std::ostream& sbn::operator<< (ExtraTriggerInfo::CryostatInfo)
 
 
 // -----------------------------------------------------------------------------

--- a/sbnobj/Common/Trigger/ExtraTriggerInfo.h
+++ b/sbnobj/Common/Trigger/ExtraTriggerInfo.h
@@ -190,6 +190,11 @@ struct sbn::ExtraTriggerInfo {
   
   /// Trigger data pertaining a single cryostat.
   struct CryostatInfo {
+    
+    /// Special value for no local cryostat trigger.
+    static constexpr unsigned int NoTrigger
+      = std::numeric_limits<unsigned int>::max();
+    
     /// Count of triggers in this cryostat.
     unsigned long int triggerCount { 0 };
     
@@ -244,6 +249,10 @@ struct sbn::ExtraTriggerInfo {
     /// @see sbn::bits::triggerLogicMask
     unsigned int triggerLogicBits { 0U };
     
+    /// Delay from the beam gate opening to the first cryostat trigger
+    /// (`NoTrigger` if no trigger is available in the cryostat) [ns]
+    unsigned int beamToTrigger { NoTrigger };
+    
     /**
      * @brief Returns the type of logic satisfied by the trigger.
      * 
@@ -269,6 +278,9 @@ struct sbn::ExtraTriggerInfo {
     
     /// Returns whether there is some recorded activity (LVDS or sector).
     constexpr bool hasAnyActivity() const;
+    
+    /// Returns whether this cryostat has a trigger in the gate.
+    constexpr bool hasTrigger() const;
     
   }; // CryostatInfo
   
@@ -346,6 +358,8 @@ struct sbn::ExtraTriggerInfo {
 
 namespace sbn {
   std::ostream& operator<< (std::ostream& out, ExtraTriggerInfo const& info);
+  std::ostream& operator<<
+    (std::ostream& out, ExtraTriggerInfo::CryostatInfo const& cryo);
 }
 
 
@@ -373,6 +387,13 @@ inline constexpr bool sbn::ExtraTriggerInfo::CryostatInfo::hasAnyActivity()
 {
   return hasLVDS() || hasSectors();
 } // sbn::ExtraTriggerInfo::CryostatInfo::hasAnyActivity()
+
+
+// -----------------------------------------------------------------------------
+inline constexpr bool sbn::ExtraTriggerInfo::CryostatInfo::hasTrigger() const
+{
+  return beamToTrigger != NoTrigger;
+} // sbn::ExtraTriggerInfo::CryostatInfo::hasTrigger()
 
 
 // -----------------------------------------------------------------------------

--- a/sbnobj/Common/Trigger/classes_def.xml
+++ b/sbnobj/Common/Trigger/classes_def.xml
@@ -27,7 +27,8 @@
     <enum name="sbn::bits::triggerSource" ClassVersion="10" />
     <enum name="sbn::bits::triggerLocation" ClassVersion="10" />
     <enum name="sbn::bits::triggerType" ClassVersion="10" />
-    <class name="sbn::ExtraTriggerInfo::CryostatInfo" ClassVersion="13" >
+    <class name="sbn::ExtraTriggerInfo::CryostatInfo" ClassVersion="14" >
+     <version ClassVersion="14" checksum="1406793077"/>
      <version ClassVersion="13" checksum="2956313925"/>
      <version ClassVersion="12" checksum="804951501"/>
      <version ClassVersion="11" checksum="3455337645"/>


### PR DESCRIPTION
ICARUS trigger hardware is going to contribute one additional information (see e.g. [SBNDocDB 36096](https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=36096) or [36264](https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=36264)).

This PR extends the `sbn::ExtraTriggerInfo` data product to accommodate for that new information, that is the time from the opening of the beam gate at which the hardware sees the trigger. This is a more direct quantification of that time than with the White Rabbit timestamp, because once the hardware takes the trigger decision, this time is frozen by the very same hardware, while it takes further time (and jitters) for the decision to reach the timestamping hardware. In the ICARUS hardware the time is measured in FPGA ticks, but the data product should store it in nanoseconds, delegating the decoding of the value upstream.
The protocol is a default value `NoTrigger` that denotes the absence of this information, a class method to test its availability (`hasTrigger()`), and direct access to the data member value (`beamToTrigger`).

The change is backward-compatible in that old data will look like they don't have this part of the trigger information. However, the additional information is mostly diagnostics for trigger study and performance evaluation, and I don't foresee physics analyses directly using it.

Reviewers:
 * @jzettle, maintainer of the ICARUS trigger decoder (which will be subject of PR SBNSoftware/icaruscode#740 to actually _fill_ the information here);
 * @mstancar as point of contact with SBND trigger expert, with the invitation to delegate as appropriate;
 * @dtorretta56 as one of the authors of the firmware change that provides the new information upstream.