### PR TITLE
add function to assign CRT-PMT Match classificaiton to sbnobj

### DIFF
--- a/sbnobj/Common/CRT/CRTPMTMatching.hh
+++ b/sbnobj/Common/CRT/CRTPMTMatching.hh
@@ -33,6 +33,42 @@ namespace sbn::crt {
       exSide_enBottom   = 14, ///< Matched with one Bottom CRT hit before the optical flash and matched with one Side CRT hit after the optical flash.
       others            = 9  ///< All the other cases.
       };
+  MatchType assignFlashClassification(uint topen, uint topex, 
+				      uint sideen, uint sideex, 
+				      uint bottomen, uint bottomex)
+  {
+    MatchType flashType;
+    if (topen == 0 && sideen == 0 && topex == 0 && sideex == 0){
+      if(bottomex==0 && bottomen==0) flashType = MatchType::noMatch;
+      else if (bottomex>=1 && bottomen==0) flashType = MatchType::exBottom;
+      else if (bottomex==0 && bottomen>=1) flashType = MatchType::enBottom;
+      else flashType = MatchType::others;
+    }
+    else if (topen == 1 && sideen == 0 && topex == 0 && sideex == 0){
+      if(bottomex==1 && bottomen==0) flashType = MatchType::enTop_exBottom;
+      else flashType = MatchType::enTop;
+    }
+    else if (topen == 0 && sideen == 1 && topex == 0 && sideex == 0)
+      if(bottomex==1 && bottomen==0) flashType = MatchType::enSide_exBottom;
+      else flashType = MatchType::enSide;
+    else if (topen == 1 && sideen == 0 && topex == 0 && sideex == 1)
+      flashType = MatchType::enTop_exSide;
+    else if (topen == 0 && sideen == 0 && topex == 1 && sideex == 0){
+      if(bottomex==0 && bottomen==1) flashType = MatchType::exTop_enBottom;
+      else flashType = MatchType::exTop;
+    }
+    else if (topen == 0 && sideen == 0 && topex == 0 && sideex == 1)
+      if(bottomex==0 && bottomen==1) flashType = MatchType::exSide_enBottom;
+      else flashType = MatchType::exSide;
+    else if (topen >= 1 && sideen == 0 && topex == 0 && sideex == 0) // could also add `if (MatchBottomCRT)` here
+      flashType = MatchType::enTop_mult; 
+    else if (topen >= 1 && sideen == 0 && topex == 0 && sideex >= 1) // and here 
+      flashType = MatchType::enTop_exSide_mult;
+    else
+      flashType = MatchType::others;
+    return flashType;
+  }
+
   /// Information about a CRT hit matched with a PMT flash.
   struct MatchedCRT {
 


### PR DESCRIPTION
This pull request adds a helper function `assignFlashClassification` that assigns a CRT-PMT Match flashClassification using the number of CRT Hits entering or exiting the detector based on the CRT-PMT Time difference value. The function reads in the number of top, side, or bottom CRT hits entering or exiting the detector and returns a [matchType](https://github.com/SBNSoftware/sbnobj/blob/develop/sbnobj/Common/CRT/CRTPMTMatching.hh#L19). This function will be called in [sbncode PR #482](https://github.com/SBNSoftware/sbncode/pull/482) and can replace these lines in the [CRTPMTMatchingUtils.cxx](https://github.com/SBNSoftware/icaruscode/blob/develop/icaruscode/CRT/CRTUtils/CRTPMTMatchingUtils.cxx#L90C1-L117C35) in icaruscode as well. 

Note: The bottom CRT is currently not used in the CRT-PMT Matching for ICARUS, so their counter variables `bottomex` and `bottomen` are left as 0. 