### PR TITLE
Enumeration for Channel Status

### DIFF
--- a/sbnobj/SBND/CRT/CRTEnums.hh
+++ b/sbnobj/SBND/CRT/CRTEnums.hh
@@ -44,6 +44,14 @@ namespace sbnd::crt {
     kThreeD = kXYZ
 
   };
+
+  enum CRTChannelStatus {
+    kGoodChannel = 0,
+    kDeadChannel,
+    KDeadNeighbourChannel,
+    kQuietChannel,
+    KQuietNeighbourChannel
+  };
 }
 
 extern sbnd::crt::CoordSet operator|(sbnd::crt::CoordSet lhs, sbnd::crt::CoordSet rhs);

--- a/sbnobj/SBND/CRT/CRTEnums.hh
+++ b/sbnobj/SBND/CRT/CRTEnums.hh
@@ -48,9 +48,9 @@ namespace sbnd::crt {
   enum CRTChannelStatus {
     kGoodChannel = 0,
     kDeadChannel,
-    KDeadNeighbourChannel,
+    kDeadNeighbourChannel,
     kQuietChannel,
-    KQuietNeighbourChannel
+    kQuietNeighbourChannel
   };
 }
 

--- a/sbnobj/SBND/CRT/classes_def.xml
+++ b/sbnobj/SBND/CRT/classes_def.xml
@@ -98,6 +98,7 @@
   <enum name="sbnd::crt::CRTTagger" ClassVersion="10"/>
   <class name="std::set<sbnd::crt::CRTTagger>"/>
   <enum name="sbnd::crt::CoordSet" ClassVersion="10"/>
+  <enum name="sbnd::crt::CRTChannelStatus" ClassVersion="10"/>
 
   <!-- associations  -->
 


### PR DESCRIPTION
It is useful to have an available enumeration for denoting the status of CRT channels (where 0 is good and 1+ are varieties of bad).

Neighbouring channels to bad channels have their own code due to the nature of the CRT readout. A bad channel neighbour will be suppressed by the bad channel.

This will be used in an sbndcode PR. It will be filled from a text file and used to suppress reconstruction for these channels and provide labeling of them in analysis modules.