### PR TITLE
Add ps to decoded TDC, allow 2 different constructors for backward compataibility

### DIFF
--- a/sbnobj/SBND/Timing/DAQTimestamp.cxx
+++ b/sbnobj/SBND/Timing/DAQTimestamp.cxx
@@ -10,20 +10,46 @@ namespace sbnd::timing {
     , fTimestamp(0)
     , fOffset(0)
     , fName("")
+    , fTimestampPs(0)
   {}
 
+  //For decoding with sbndcode <= v10_04_??
   DAQTimestamp::DAQTimestamp(uint32_t channel, uint64_t timestamp, uint64_t offset, std::string name)
     : fChannel(channel)
     , fTimestamp(timestamp)
     , fOffset(offset)
     , fName(name)
+    , fTimestampPs(0)
   {}
 
+  //For decoding with sbndcode <= v10_04_??
   DAQTimestamp::DAQTimestamp(uint32_t channel, uint64_t timestamp, uint64_t offset, std::array<char, 8> name)
     : fChannel(channel)
     , fTimestamp(timestamp)
     , fOffset(offset)
     , fName("")
+    , fTimestampPs(0)
+  {
+    for(auto const& c : name)
+      fName.push_back(c);
+  }
+
+  //New addition for sbndcode version > v10_04_??
+  DAQTimestamp::DAQTimestamp(uint32_t channel, uint64_t timestamp, uint64_t offset, std::string name, uint64_t timestampPs)
+    : fChannel(channel)
+    , fTimestamp(timestamp)
+    , fOffset(offset)
+    , fName(name)
+    , fTimestampPs(timestampPs)
+  {}
+
+  //New addition for sbndcode version > v10_04_??
+  DAQTimestamp::DAQTimestamp(uint32_t channel, uint64_t timestamp, uint64_t offset, std::array<char, 8> name, uint64_t timestampPs)
+    : fChannel(channel)
+    , fTimestamp(timestamp)
+    , fOffset(offset)
+    , fName("")
+    , fTimestampPs(timestampPs)
   {
     for(auto const& c : name)
       fName.push_back(c);
@@ -51,6 +77,11 @@ namespace sbnd::timing {
     return fName;
   }
 
+  uint64_t DAQTimestamp::TimestampPs() const
+  {
+    return fTimestampPs;
+  }
+
   void DAQTimestamp::SetChannel(uint32_t channel)
   {
     fChannel = channel;
@@ -69,6 +100,11 @@ namespace sbnd::timing {
   void DAQTimestamp::SetName(std::string name)
   {
     fName = name;
+  }
+
+  void DAQTimestamp::SetTimestampPs(uint64_t timestamp)
+  {
+    fTimestampPs = timestamp;
   }
 }
 

--- a/sbnobj/SBND/Timing/DAQTimestamp.hh
+++ b/sbnobj/SBND/Timing/DAQTimestamp.hh
@@ -21,6 +21,9 @@ namespace sbnd::timing {
     uint64_t fTimestamp; ///< Timestamp of signal [ns]
     uint64_t fOffset;    ///< Channel specific offset [ns]
     std::string fName;   ///< Name of channel input
+    
+    //New addition for sbndcode version > v10_04_??
+    uint64_t fTimestampPs; ///< Timestamp of signal [ps]
 
    public:
 
@@ -30,24 +33,28 @@ namespace sbnd::timing {
     DAQTimestamp();
 
     /**
-     * Constructor to set all parameters
+     * Constructor to set 4 parameters but timestamp ps
+     * For decoding with sbndcode <= v10_04_??
      *
      * @param channel    Hardware channel
-     * @param timestamp  Timestamp of signal [ns]
+     * @param timestamp  Timestamp of signal [ns] in UTC format
      * @param offset     Channel specific offset [ns]
      * @param name       Name of channel input
      */
     DAQTimestamp(uint32_t channel, uint64_t timestamp, uint64_t offset, std::string name);
+    DAQTimestamp(uint32_t channel, uint64_t timestamp, uint64_t offset, std::array<char, 8> name);
 
     /**
-     * Constructor to set all parameters, using array for name
+     * Constructor to set all parameters 
+     * For decoding with sbndcode > v10_04_??
      *
      * @param channel    Hardware channel
-     * @param timestamp  Timestamp of signal [ns]
+     * @param timestamp  Timestamp of signal [ns] in UTC format
      * @param offset     Channel specific offset [ns]
      * @param name       Name of channel input
      */
-    DAQTimestamp(uint32_t channel, uint64_t timestamp, uint64_t offset, std::array<char, 8> name);
+    DAQTimestamp(uint32_t channel, uint64_t timestamp, uint64_t offset, std::string name, uint64_t timestampPs);
+    DAQTimestamp(uint32_t channel, uint64_t timestamp, uint64_t offset, std::array<char, 8> name, uint64_t timestampPs);
 
     /**
      * Destructor
@@ -61,6 +68,9 @@ namespace sbnd::timing {
     uint64_t    Timestamp() const;
     uint64_t    Offset() const;
     std::string Name() const;
+    
+    //New addition for sbndcode version > v10_04_??
+    uint64_t    TimestampPs() const;
  
     /**
      * Setters
@@ -69,6 +79,9 @@ namespace sbnd::timing {
     void SetTimestamp(uint64_t timestamp);
     void SetOffset(uint64_t offset);
     void SetName(std::string name);
+
+    //New addition for sbndcode version > v10_04_??
+    void SetTimestampPs(uint64_t timestamp);
   };
 }
 

--- a/sbnobj/SBND/Timing/classes_def.xml
+++ b/sbnobj/SBND/Timing/classes_def.xml
@@ -1,5 +1,6 @@
 <lcgdict>
-  <class name="sbnd::timing::DAQTimestamp" ClassVersion="10">
+  <class name="sbnd::timing::DAQTimestamp" ClassVersion="11">
+   <version ClassVersion="11" checksum="2804806845"/>
     <version ClassVersion="10" checksum="810700615"/>
   </class>
   <class name="std::vector<sbnd::timing::DAQTimestamp>"/>


### PR DESCRIPTION
The fix introduces a new variable `timestampPs` in the decoded TDC object `sbnd::timing::DAQTimestamp`.

Enable 2 ways to construct the `sbnd::timing::DAQTimestamp`, with and without `timestampPs` to enable backward compatibility.

In case the object is constructed without `timestampPs`, the variable is defaulted to 0.

In case the object is constructed with `timestampPs`, the variable is  set to the provided value.
