### PR TITLE
Add hit goodness to sbn::HitInfo

### DIFF
--- a/sbnobj/Common/Calibration/TrackCaloSkimmerObj.h
+++ b/sbnobj/Common/Calibration/TrackCaloSkimmerObj.h
@@ -45,6 +45,7 @@ namespace sbn {
     float integral; //!< Integral of gaussian fit to ADC values in hit [ADC]
     float sumadc; //!< "SummedADC" -- sum of ADC values under gaussian fit [ADC]
     float width; //!< Width of fitted gaussian hit [ticks]
+    float goodness; //!< Goodness-of-fit of fitted gaussian hit
     Vector3D sp; //!< Space-Point Position of hit [cm]
     float time; //!< Peak time of hit [ticks]
     int id; //!< ID of hit

--- a/sbnobj/Common/Calibration/classes_def.xml
+++ b/sbnobj/Common/Calibration/classes_def.xml
@@ -32,7 +32,8 @@
   <class name="sbn::HitTruth" ClassVersion="10">
    <version ClassVersion="10" checksum="2374511199"/>
   </class>
-  <class name="sbn::HitInfo" ClassVersion="15">
+  <class name="sbn::HitInfo" ClassVersion="16">
+   <version ClassVersion="16" checksum="1013657270"/>
    <version ClassVersion="15" checksum="2112326324"/>
    <version ClassVersion="14" checksum="2279804458"/>
    <version ClassVersion="13" checksum="3388532746"/>


### PR DESCRIPTION
It is sometimes useful to exclude hits with poor fits when doing analysis with the calibration ntuples. This PR adds a field to store the `recob::Hit::GoodnessOfFit` score to the `sbn::HitInfo` object so that it is available in the calibration ntuples. See corresponding PR in sbncode for implementation in `TrackCaloSkimmer_module.cc`.

Associated sbncode PR: https://github.com/SBNSoftware/sbncode/pull/512