### PR TITLE
Add category to enum for unused channel

### DIFF
--- a/sbnobj/SBND/CRT/CRTEnums.hh
+++ b/sbnobj/SBND/CRT/CRTEnums.hh
@@ -50,7 +50,8 @@ namespace sbnd::crt {
     kDeadChannel,
     kDeadNeighbourChannel,
     kQuietChannel,
-    kQuietNeighbourChannel
+    kQuietNeighbourChannel,
+    kUnusedChannel
   };
 }
 


### PR DESCRIPTION
With the way the MINOS modules are connected to the readout FEBs 30 (10 each from 3 modules) of the 32 channels on the FEB are connected to a SiPM. This leaves 2 channels per FEB (only 2 FEBs so 4 in total in the system). Which will readout but are not connected to a SiPM, dead or otherwise! I would like to have a simple indication of this and this seems the obvious way to do this.

We don't actually need this category to exist quite yet but I thought of it whilst preparing the CRT inputs to the calibration database and thought it was worth pre-empting given it's a very simple change.