### PR TITLE
Ints -> Doubles for low-level CRT reco

### DIFF
--- a/sbnobj/SBND/CRT/CRTCluster.cxx
+++ b/sbnobj/SBND/CRT/CRTCluster.cxx
@@ -16,7 +16,7 @@ namespace sbnd {
       , fComposition  (kUndefinedSet)
     {}
 
-    CRTCluster::CRTCluster(int64_t _ts0, int64_t _ts1, uint32_t _unixS, uint16_t _nHits, CRTTagger _tagger,
+    CRTCluster::CRTCluster(double _ts0, double _ts1, uint32_t _unixS, uint16_t _nHits, CRTTagger _tagger,
                            CoordSet _composition)
       : fTs0          (_ts0)
       , fTs1          (_ts1)
@@ -28,8 +28,8 @@ namespace sbnd {
 
     CRTCluster::~CRTCluster() {}
 
-    int64_t   CRTCluster::Ts0() const { return fTs0; }
-    int64_t   CRTCluster::Ts1() const { return fTs1; }
+    double    CRTCluster::Ts0() const { return fTs0; }
+    double    CRTCluster::Ts1() const { return fTs1; }
     uint32_t  CRTCluster::UnixS() const { return fUnixS; }
     uint16_t  CRTCluster::NHits() const { return fNHits; }
     CRTTagger CRTCluster::Tagger() const { return fTagger; }

--- a/sbnobj/SBND/CRT/CRTCluster.hh
+++ b/sbnobj/SBND/CRT/CRTCluster.hh
@@ -16,8 +16,8 @@ namespace sbnd::crt {
 
   class CRTCluster {
     
-    int64_t   fTs0;           // T0 counter [ns]
-    int64_t   fTs1;           // T1 counter [ns]
+    double    fTs0;          // T0 counter [ns]
+    double    fTs1;          // T1 counter [ns]
     uint32_t  fUnixS;        // Unixtime of event [s]
     uint16_t  fNHits;        // The number of strip hits forming the cluster
     CRTTagger fTagger;       // The tagger this cluster exists on
@@ -27,13 +27,13 @@ namespace sbnd::crt {
 
     CRTCluster();
     
-    CRTCluster(int64_t _ts0, int64_t _ts1, uint32_t _unixS, uint16_t _nHits, CRTTagger _tagger,
+    CRTCluster(double _ts0, double _ts1, uint32_t _unixS, uint16_t _nHits, CRTTagger _tagger,
                CoordSet _composition);
 
     virtual ~CRTCluster();
 
-    int64_t   Ts0() const;
-    int64_t   Ts1() const;
+    double    Ts0() const;
+    double    Ts1() const;
     uint32_t  UnixS() const;
     uint16_t  NHits() const;
     CRTTagger Tagger() const;

--- a/sbnobj/SBND/CRT/CRTStripHit.cxx
+++ b/sbnobj/SBND/CRT/CRTStripHit.cxx
@@ -20,7 +20,7 @@ namespace sbnd {
       , fSaturated2   (false)
     {}
 
-    CRTStripHit::CRTStripHit(uint32_t _channel, int64_t _ts0, int64_t _ts1, uint32_t _s, double _pos,
+    CRTStripHit::CRTStripHit(uint32_t _channel, double _ts0, double _ts1, uint32_t _s, double _pos,
                              double _err, uint16_t _adc1, uint16_t _adc2)
       : fChannel      (_channel)
       , fTs0          (_ts0)
@@ -35,7 +35,7 @@ namespace sbnd {
       fSaturated2 = fADC2 == 4095;
     }
 
-    CRTStripHit::CRTStripHit(uint32_t _channel, int64_t _ts0, int64_t _ts1, uint32_t _s, double _pos,
+    CRTStripHit::CRTStripHit(uint32_t _channel, double _ts0, double _ts1, uint32_t _s, double _pos,
                              double _err, uint16_t _adc1, uint16_t _adc2, bool _saturated1, bool _saturated2)
       : fChannel      (_channel)
       , fTs0          (_ts0)
@@ -52,8 +52,8 @@ namespace sbnd {
     CRTStripHit::~CRTStripHit() {}
 
     uint32_t CRTStripHit::Channel() const { return fChannel; }
-    int64_t  CRTStripHit::Ts0() const { return fTs0; }
-    int64_t  CRTStripHit::Ts1() const { return fTs1; }
+    double   CRTStripHit::Ts0() const { return fTs0; }
+    double   CRTStripHit::Ts1() const { return fTs1; }
     uint32_t CRTStripHit::UnixS() const { return fUnixS; }
     double   CRTStripHit::Pos() const { return fPos; }
     double   CRTStripHit::Error() const { return fErr; }

--- a/sbnobj/SBND/CRT/CRTStripHit.hh
+++ b/sbnobj/SBND/CRT/CRTStripHit.hh
@@ -17,8 +17,8 @@ namespace sbnd::crt {
   class CRTStripHit {
     
     uint32_t fChannel;      // Channel ID for 1st SiPM
-    int64_t  fTs0;          // T0 counter [ns] - Time relative to pulse-per-second
-    int64_t  fTs1;          // T1 counter [ns] - Time relative to some beam signal
+    double   fTs0;          // T0 counter [ns] - Time relative to pulse-per-second
+    double   fTs1;          // T1 counter [ns] - Time relative to some beam signal
     uint32_t fUnixS;        // Unixtime of event [s]
     double   fPos;          // Lateral position within strip [cm]
     double   fErr;          // Error on lateral position [cm]
@@ -31,17 +31,17 @@ namespace sbnd::crt {
 
     CRTStripHit();
     
-    CRTStripHit(uint32_t _channel, int64_t _ts0, int64_t _ts1, uint32_t _s, double _pos,
+    CRTStripHit(uint32_t _channel, double _ts0, double _ts1, uint32_t _s, double _pos,
                 double _err, uint16_t _adc1, uint16_t _adc2);
 
-    CRTStripHit(uint32_t _channel, int64_t _ts0, int64_t _ts1, uint32_t _s, double _pos,
+    CRTStripHit(uint32_t _channel, double _ts0, double _ts1, uint32_t _s, double _pos,
                 double _err, uint16_t _adc1, uint16_t _adc2, bool _saturated1, bool _saturated2);
 
     virtual ~CRTStripHit();
 
     uint32_t Channel() const;
-    int64_t  Ts0() const;
-    int64_t  Ts1() const;
+    double   Ts0() const;
+    double   Ts1() const;
     uint32_t UnixS() const;
     double   Pos() const;
     double   Error() const;

--- a/sbnobj/SBND/CRT/classes_def.xml
+++ b/sbnobj/SBND/CRT/classes_def.xml
@@ -68,7 +68,8 @@
 
   <!-- CRTStripHit -->
 
-  <class name="sbnd::crt::CRTStripHit" ClassVersion="11">
+  <class name="sbnd::crt::CRTStripHit" ClassVersion="12">
+    <version ClassVersion="12" checksum="2450467372"/>
     <version ClassVersion="11" checksum="1377866194"/>
     <version ClassVersion="10" checksum="584045954"/>
   </class>
@@ -85,7 +86,8 @@
 
   <!-- CRTCluster -->
 
-  <class name="sbnd::crt::CRTCluster" ClassVersion="11">
+  <class name="sbnd::crt::CRTCluster" ClassVersion="12">
+    <version ClassVersion="12" checksum="1193265154"/>
     <version ClassVersion="11" checksum="2461267624"/>
     <version ClassVersion="10" checksum="1135665496"/>
   </class>


### PR DESCRIPTION
As is described in SBNSoftware/sbndcode#705 we require the low-level CRT objects to store timings as doubles not integers from now on. This is due to calibrated timing delays that are fractional.