### PR TITLE
Update definitions for new trigger variables for the cafs

### DIFF
--- a/sbnobj/Common/Trigger/ExtraTriggerInfo.h
+++ b/sbnobj/Common/Trigger/ExtraTriggerInfo.h
@@ -89,18 +89,6 @@ struct sbn::ExtraTriggerInfo {
   /// Incremental counter of gates from this source opened from start of the run.
   unsigned int gateCount { 0 };
 
-  // Boolean telling if the event passed the trigger
-  bool triggerEmulation { false };
-
-  // Number of PMT pairs over the trigger threshold
-  int pairsOverThreshold { 0 };
-
-  // Trigger responses for all of the waveforms in the event (flattened)
-  std::vector<int> MonPulses { std::vector<int>() }; // default ???
-
-  // Length of each trigger response to unflatten the trigger responses
-  std::vector<int> MonPulseSizes { std::vector<int>() }; 
-
   /// @}
   // --- END ---- Since the beginning of the run -------------------------------
   

--- a/sbnobj/Common/Trigger/classes_def.xml
+++ b/sbnobj/Common/Trigger/classes_def.xml
@@ -19,7 +19,8 @@
   <!-- sbn::ExtraTriggerInfo -->
 
   <!--   class -->
-  <class name="sbn::ExtraTriggerInfo" ClassVersion="11" >
+  <class name="sbn::ExtraTriggerInfo" ClassVersion="12" >
+   <version ClassVersion="12" checksum="1967722932"/>
    <version ClassVersion="11" checksum="587699878"/>
    <version ClassVersion="10" checksum="1967722932"/>
   </class>


### PR DESCRIPTION
### Description 
This includes updates to ExtraTriggerInfo to take trigger data products from detsim to be able to put them in the cafs: the variables include a bool of passed/failed trigger, number of PMT pairs over threshold, and two variables for the purpose of validation giving us the trigger response in a flattened vector and the size of the pulses (so the vector can be un-flattened).

This pull request must be merged after the [detsim updates](https://github.com/SBNSoftware/sbndcode/pull/830) and with the other updates for the CAF files: [sbnanaobj](https://github.com/SBNSoftware/sbnanaobj/pull/161) and [sbncode](https://github.com/SBNSoftware/sbncode/pull/583).

- [X] Have you added a label? (bug/enhancement/physics etc.)
- [X] Have you assigned at least 1 reviewer?
- [X] Is this PR related to an open issue / project?
- [X] Does this PR affect CAF data format? If so, please assign a CAF maintainer as additional reviewer.
- [X] Does this PR require merging another PR in a different repository (such as sbnanobj/sbnobj etc.)? If so, please link it in the description.
- [X] Are you submitting this PR on behalf of someone else who made the code changes? If so, please mention them in the description.
