### PR TITLE
Update CorrectedOpFlash attributes

### DIFF
--- a/sbnobj/Common/Reco/CorrectedOpFlashTiming.h
+++ b/sbnobj/Common/Reco/CorrectedOpFlashTiming.h
@@ -24,24 +24,11 @@ namespace sbn {
   /// @name Corrected OpFlash Times
   /// @{
   float        OpFlashT0             { fDefault };                   ///< | OpFlash Time wrt RWM time | (ns)
-  float        UpstreamTime_lightonly             { fDefault };      ///< | Nu upstream wall time reconstructed using light only | (ns)
-  float        UpstreamTime_tpczcorr             { fDefault };       ///< | Nu upstream wall time reconstructed using light and Z from tpc vertex | (ns)
-  float        UpstreamTime_propcorr_tpczcorr    { fDefault };       ///< | Nu upstream wall time reconstructed using light propagation correction from tpc information and z correction from tpc vertex | (ns)
+  float        NuToFLight             { fDefault };      ///< | Nu ToF using light only | (ns)
+  float        NuToFCharge             { fDefault };       ///< | Nu ToF Z from tpc vertex | (ns)
+  float        OpFlashT0Corrected    { fDefault };       ///< | OpFlash Time wrt RWM time after light propagation corrections | (ns)
+  /// @}
   
-  /// @}
-
-  /// @name Data members related to the slice-flash match
-  /// @{
-  float        FMScore             { fDefault };                   ///< | OpFlash Time wrt RWM time | (ns)
-
-  /// @}
-
-  /// @name Data members related to the slice match
-  /// @{
-  float        SliceNuScore             { fDefault };                   ///< | OpFlash Time wrt RWM time | (ns)
-
-  /// @}
-
   };
 }
 

--- a/sbnobj/Common/Reco/classes_def.xml
+++ b/sbnobj/Common/Reco/classes_def.xml
@@ -292,7 +292,8 @@
 
   <class name="std::vector<geo::PlaneID>"/>
 
-  <class name="sbn::CorrectedOpFlashTiming" ClassVersion="15">
+  <class name="sbn::CorrectedOpFlashTiming" ClassVersion="16">
+   <version ClassVersion="16" checksum="1734226620"/>
    <version ClassVersion="15" checksum="2401924061"/>
    <version ClassVersion="14" checksum="2635318722"/>
    <version ClassVersion="13" checksum="328467396"/>


### PR DESCRIPTION
Remove CorrectedOpFlash attributes that can be found via slice-correctedopflash assns. It also changes the attributes to reflect each of the corrections separately.

Merging this PR solves https://github.com/SBNSoftware/sbnanaobj/issues/160 .

