### PR TITLE
Change tagger storage from set to vector

### DIFF
--- a/sbnobj/SBND/CRT/CRTTrack.cxx
+++ b/sbnobj/SBND/CRT/CRTTrack.cxx
@@ -20,7 +20,7 @@ namespace sbnd {
 
     CRTTrack::CRTTrack(const geo::Point_t &_start, const geo::Point_t &_end, const double &_ts0, const double &_ets0,
                        const double &_ts1, const double &_ets1, const double &_pe, const double &_tof,
-                       const std::set<CRTTagger> &_taggers)
+                       const std::vector<CRTTagger> &_taggers)
       : fPoints  ({_start, _end})
       , fTs0     (_ts0)
       , fTs0Err  (_ets0)
@@ -33,7 +33,7 @@ namespace sbnd {
 
     CRTTrack::CRTTrack(const std::vector<geo::Point_t> &_points, const double &_ts0, const double &_ets0,
                        const double &_ts1, const double &_ets1, const double &_pe, const double &_tof,
-                       const std::set<CRTTagger> &_taggers)
+                       const std::vector<CRTTagger> &_taggers)
       : fPoints  (_points)
       , fTs0     (_ts0)
       , fTs0Err  (_ets0)
@@ -53,7 +53,7 @@ namespace sbnd {
     double                    CRTTrack::Ts1Err() const { return fTs1Err; }
     double                    CRTTrack::PE() const { return fPE; }
     double                    CRTTrack::ToF() const { return fToF; }
-    std::set<CRTTagger>       CRTTrack::Taggers() const { return fTaggers; }
+    std::vector<CRTTagger>    CRTTrack::Taggers() const { return fTaggers; }
 
     geo::Point_t  CRTTrack::Start() const { return fPoints.front(); }
     geo::Point_t  CRTTrack::End() const { return fPoints.back(); }
@@ -63,7 +63,16 @@ namespace sbnd {
     double        CRTTrack::Phi() const { return (End() - Start()).Phi(); }
     bool          CRTTrack::Triple() const { return fTaggers.size() == 3; }
 
-    bool CRTTrack::UsedTagger(const CRTTagger tagger) const { return fTaggers.count(tagger) == 1; }
+    bool CRTTrack::UsedTagger(const CRTTagger tagger) const
+    {
+      for(const CRTTagger track_tagger : fTaggers)
+	{
+	  if(track_tagger == tagger)
+	    return true;
+	}
+
+      return false;
+    }
   }
 }
 

--- a/sbnobj/SBND/CRT/CRTTrack.hh
+++ b/sbnobj/SBND/CRT/CRTTrack.hh
@@ -13,7 +13,6 @@
 #include "larcoreobj/SimpleTypesAndConstants/geo_vectors.h"
 #include "sbnobj/SBND/CRT/CRTEnums.hh"
 
-#include <set>
 #include <vector>
 
 namespace sbnd::crt {
@@ -27,7 +26,7 @@ namespace sbnd::crt {
     double                    fTs1Err;  // average time error according to T1 clock [ns]
     double                    fPE;      // total PE
     double                    fToF;     // time from first space point to last [ns]
-    std::set<CRTTagger>       fTaggers; // which taggers were used to create the track
+    std::vector<CRTTagger>    fTaggers; // which taggers were used to create the track
 
   public:
 
@@ -35,11 +34,11 @@ namespace sbnd::crt {
     
     CRTTrack(const geo::Point_t &_start, const geo::Point_t &_end, const double &_ts0, const double &_ets0,
              const double &_ts1, const double &_ets1, const double &_pe, const double &_tof,
-             const std::set<CRTTagger> &_taggers);
+             const std::vector<CRTTagger> &_taggers);
 
     CRTTrack(const std::vector<geo::Point_t> &_points, const double &_ts0, const double &_ets0,
              const double &_ts1, const double &_ets1, const double &_pe, const double &_tof,
-             const std::set<CRTTagger> &_taggers);
+             const std::vector<CRTTagger> &_taggers);
 
     virtual ~CRTTrack();
 
@@ -50,7 +49,7 @@ namespace sbnd::crt {
     double                    Ts1Err() const;
     double                    PE() const;
     double                    ToF() const;
-    std::set<CRTTagger>       Taggers() const;
+    std::vector<CRTTagger>    Taggers() const;
 
     geo::Point_t  Start() const;
     geo::Point_t  End() const;

--- a/sbnobj/SBND/CRT/classes_def.xml
+++ b/sbnobj/SBND/CRT/classes_def.xml
@@ -100,6 +100,7 @@
 
   <enum name="sbnd::crt::CRTTagger" ClassVersion="10"/>
   <class name="std::set<sbnd::crt::CRTTagger>"/>
+  <class name="std::vector<sbnd::crt::CRTTagger>"/>
   <enum name="sbnd::crt::CoordSet" ClassVersion="10"/>
   <enum name="sbnd::crt::CRTChannelStatus" ClassVersion="10"/>
 
@@ -139,7 +140,8 @@
 
   <!-- CRTTrack -->
 
-  <class name="sbnd::crt::CRTTrack" ClassVersion="11">
+  <class name="sbnd::crt::CRTTrack" ClassVersion="12">
+    <version ClassVersion="12" checksum="1512565828"/>
     <version ClassVersion="11" checksum="2489926563"/>
     <version ClassVersion="10" checksum="1691600150"/>
   </class>


### PR DESCRIPTION
CRT Tracks have a `Points` and `Taggers` field. They both describe the 2 or 3 `CRTSpacePoint`s used to create them. The former describes the cartesian xyz of each point, the latter just enumerates which walls those points were in.

The `Taggers` field was originally constructed as a `set` which means the correspondence between `Points` and `Taggers` was lost. This PR amends this to make it a `vector` thus preserving the order.