### PR TITLE
Removal of detrimental dependency of sbnobj::Common_CRT 

### DIFF
--- a/sbnobj/Common/CRT/CMakeLists.txt
+++ b/sbnobj/Common/CRT/CMakeLists.txt
@@ -8,8 +8,8 @@ cet_make_library(
     CRTHitT0TaggingTruthInfo.cc
     LIBRARIES
     cetlib_except::cetlib_except
-    lardataobj::Simulation
-    larcorealg::Geometry
+    larcoreobj::headers
+    lardataobj::Simulation # for associations to sim::AuxDetIDE
   )
 
 art_dictionary(DICTIONARY_LIBRARIES sbnobj::Common_CRT)

--- a/sbnobj/Common/CRT/CRTHitT0TaggingInfo.hh
+++ b/sbnobj/Common/CRT/CRTHitT0TaggingInfo.hh
@@ -9,9 +9,9 @@
 
 // C/C++ standard libraries
 #include <limits>
-#include "larcorealg/Geometry/GeometryCore.h"
 #include "larcoreobj/SimpleTypesAndConstants/geo_types.h"
 #include "larcoreobj/SimpleTypesAndConstants/geo_vectors.h"
+
 // -----------------------------------------------------------------------------
 namespace sbn::crt { 
   /// @brief How was the track fitted when matched with a CRT hit.

--- a/sbnobj/Common/CRT/CRTPMTMatching.hh
+++ b/sbnobj/Common/CRT/CRTPMTMatching.hh
@@ -59,10 +59,10 @@ namespace sbn::crt {
     static constexpr int NoLocation = -1;
 
     geo::Point_t position;           ///< Hit location [cm]
-    double PMTTimeDiff; //= NoTime;     < CRT hit time minus PMT flash time [us] (instead maybe wanna set NoTime vars in 
-    double time;//        = NoTime;     ///< CRT hit time [us]
-    int sys;     //       = NoLocation; ///< CRT subdetector the hit fell into.
-    int region;//         = NoLocation; ///< Region the matched CRT hit fell into.
+    double PMTTimeDiff = NoTime;     ///< CRT hit time minus PMT flash time [us]
+    double time        = NoTime;     ///< CRT hit time [us]
+    int sys            = NoLocation; ///< CRT subdetector the hit fell into.
+    int region         = NoLocation; ///< Region the matched CRT hit fell into.
   };
 
   struct CRTPMTMatching{
@@ -83,18 +83,18 @@ namespace sbn::crt {
     static constexpr double NoWidth = -1.0;
 
 
-    int          flashID;//             = NoID;    ///< ID of the optical flash.
-    double       flashTime;//           = NoTime;  ///< Time of the optical flash w.r.t. the global trigger [us]
-    double       flashGateTime;//       = NoTime;  ///< Time of the optical flash w.r.t. the beam gate opening [us]
-    double       firstOpHitPeakTime;//  = NoTime;  ///< Time of the first optical hit peak time w.r.t. the global trigger [us]
-    double       firstOpHitStartTime;// = NoTime;  ///< Time of the first optical hit start time w.r.t. the global trigger [us]
-    bool         flashInGate;//         = false;   ///< Flash within gate or not.
-    bool         flashInBeam ;//        = false;   ///< Flash within the beam window of the gate or not.
-    double       flashPE;//             = -1.0;    ///< Total reconstructed light in the flash [photoelectrons]
+    int          flashID             = NoID;    ///< ID of the optical flash.
+    double       flashTime           = NoTime;  ///< Time of the optical flash w.r.t. the global trigger [us]
+    double       flashGateTime       = NoTime;  ///< Time of the optical flash w.r.t. the beam gate opening [us]
+    double       firstOpHitPeakTime  = NoTime;  ///< Time of the first optical hit peak time w.r.t. the global trigger [us]
+    double       firstOpHitStartTime = NoTime;  ///< Time of the first optical hit start time w.r.t. the global trigger [us]
+    bool         flashInGate         = false;   ///< Flash within gate or not.
+    bool         flashInBeam         = false;   ///< Flash within the beam window of the gate or not.
+    double       flashPE             = -1.0;    ///< Total reconstructed light in the flash [photoelectrons]
     geo::Point_t flashPosition;                 ///< Flash barycenter coordinates evaluated using ADCs as weights.
-    double       flashYWidth;//         = NoWidth; ///< Flash spread along Y.
-    double       flashZWidth;//         = NoWidth; ///< Flash spread along Z. 
-    MatchType    flashClassification;// = MatchType::noMatch; ///< Classification of the optical flash.
+    double       flashYWidth         = NoWidth; ///< Flash spread along Y.
+    double       flashZWidth         = NoWidth; ///< Flash spread along Z. 
+    MatchType    flashClassification = MatchType::noMatch; ///< Classification of the optical flash.
     std::vector<MatchedCRT> matchedCRTHits;     ///< Matched CRT Hits with the optical flash.
     unsigned int nTopCRTHitsBefore   = NoCount; ///< Number of Top CRT Hits before the optical flash.
     unsigned int nTopCRTHitsAfter    = NoCount; ///< Number of Top CRT Hits after the optical flash.


### PR DESCRIPTION
This branch provides two different, unrelated maintenance changes:
1. removed dependency of `sbnobj::Common_CRT` from `larcorealg::Geometry`
2. initialisation of `sbn::crt::CRTPMTMatching` data members

Explanations follow.

This PR is based on `develop` of `sbnobj`. It is also needed by ICARUS, which is not up to date with this `sbnobj` version (around `v10_11_00`, while ICARUS `develop` is stuck at `v10_06_xx`).

Reviewers:
 * @aheggest as author of changes being reverted
 * @francescopoppi as the person reporting the issue
 * Copilot for the laugh


### Dependency of `sbnobj::Common_CRT` from `larcorealg::Geometry`

`sbnobj/Common/CRT/CRTHitT0TaggingInfo.hh` used to include on `larcorealg/Geometry/GeometryCore.h` for no reason, and, accordingly, the `sbnobj::Common_CRT` library was linked to `larcorealg::Geometry`.
Whenever ROOT (interactive) is requested a CRT data class (`sbn::crt::CRTHit`, `sbn::crt::CRTHitT0TaggingInfo`... anything in that library), it loads `sbnobj::Common_CRT` library, then loads `larcorealg::Geometry` and its header `GeometryCore.h`.
Currently ROOT is not able to load that header, with the error:
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  module "span" {
         ^
/cvmfs/larsoft.opensciencegrid.org/products/range/v3_0_12_0/include/range/v3/range/concepts.hpp:25:10: note: submodule of top-level module 'std' implicitly imported here
#include <span>
         ^
/cvmfs/larsoft.opensciencegrid.org/products/root/v6_28_12/Linux64bit+3.10-2.17-e26-p3915-prof/etc/cling/std.modulemap:312:10: error: module 'std.span' requires feature 'cplusplus20'
  module "span" {
         ^
/cvmfs/larsoft.opensciencegrid.org/products/range/v3_0_12_0/include/range/v3/range/access.hpp:27:10: note: submodule of top-level module 'std' implicitly imported here
#include <span>
         ^
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
and therefore fails to load the `sbn::crt` class.
This inclusion and link is likely a residual from earlier versions of the class, but it is superfluous now.

So I removed it.

### Initialisation of `sbn::crt::CRTPMTMatching`

For an unknown reason, the inline initialisation of the data members of `sbn::crt::CRTPMTMatching` was commented out during the move from `icaruscode` to `sbnobj`.
I am restoring them, since we do not want uninitialised data wandering across our data files.
I am calling for a review by @aheggest, who led the move in 2023, in case she remembers a rationale behind that choice.
