### PR TITLE
Add CRT-PMT flash classification to TPC-PMT flash-matching producer

### DIFF
--- a/sbnobj/Common/Reco/TPCPMTBarycenterMatch.h
+++ b/sbnobj/Common/Reco/TPCPMTBarycenterMatch.h
@@ -21,6 +21,7 @@ namespace sbn {
 
   // NaN value to initialize data members
   static constexpr float fDefault = std::numeric_limits<float>::signaling_NaN();
+  static constexpr int fIntDefault = std::numeric_limits<int>::signaling_NaN();
 
   /// @name Data members related to the slice barycenter determination
   /// @{
@@ -33,12 +34,13 @@ namespace sbn {
 
   /// @name Data members related to matched recob::OpFlash, also reachable by association 
   /// @{
-  float        flashTime          { fDefault };                     ///< Matched OpFlash time (us)
-  float        flashFirstHit      { fDefault };                     ///< Time of first OpHit in matched OpFlash (us)
-  float        flashPEs           { fDefault };                     ///< Total PEs in matched flash
-  float        flashAsymmetry     { fDefault };                     ///< East-West asymmetry of PEs in matched flash
-  geo::Point_t flashCenter        { fDefault, fDefault, fDefault }; ///< Weighted mean ophit position in X,Y,Z [no meaingful X info for ophits] (cm)
-  geo::Vector_t flashWidth        { fDefault, fDefault, fDefault }; ///< Weighted standard devitation of ophit position in X,Y,Z [no meaingful X info for ophits] (cm)
+  float        flashTime                { fDefault };                     ///< Matched OpFlash time (us)
+  float        flashFirstHit            { fDefault };                     ///< Time of first OpHit in matched OpFlash (us)
+  float        flashPEs                 { fDefault };                     ///< Total PEs in matched flash
+  float        flashAsymmetry           { fDefault };                     ///< East-West asymmetry of PEs in matched flash
+  geo::Point_t flashCenter              { fDefault, fDefault, fDefault }; ///< Weighted mean ophit position in X,Y,Z [no meaingful X info for ophits] (cm)
+  geo::Vector_t flashWidth              { fDefault, fDefault, fDefault }; ///< Weighted standard devitation of ophit position in X,Y,Z [no meaingful X info for ophits] (cm)
+  int           flashClassification     { fIntDefault };                  ///< Flash classification according to the CRT-PMT matching
   /// @}
 
 

--- a/sbnobj/Common/Reco/classes_def.xml
+++ b/sbnobj/Common/Reco/classes_def.xml
@@ -266,7 +266,8 @@
   <class name="art::Wrapper<art::Assns<sbn::MVAPID, recob::PFParticle>>" />
   <class name="art::Wrapper<art::Assns<sbn::MVAPID, recob::PFParticle, recob::Track>>" />
 
-  <class name="sbn::TPCPMTBarycenterMatch" ClassVersion="10">
+  <class name="sbn::TPCPMTBarycenterMatch" ClassVersion="11">
+   <version ClassVersion="11" checksum="1090705183"/>
    <version ClassVersion="10" checksum="3504890228"/>
   </class>
   <class name="std::vector<sbn::TPCPMTBarycenterMatch>" />


### PR DESCRIPTION
This PR (based off of `v10_00_05`) adds the flash classification from the CRT-PMT matching information to the best-matched flash in the TPC-PMT barycenter flash-matching producer. 

___
### Associated PRs

- https://github.com/SBNSoftware/icaruscode/pull/875
- https://github.com/SBNSoftware/sbnanaobj/pull/179
- https://github.com/SBNSoftware/sbncode/pull/613

___
### Review

Tagging for review @francescopoppi and @PetrilloAtWork as the CRT & light gurus. Thanks!