### PR TITLE
CRT Blobs

### DIFF
--- a/sbnobj/SBND/CRT/CMakeLists.txt
+++ b/sbnobj/SBND/CRT/CMakeLists.txt
@@ -7,6 +7,7 @@ cet_make_library(
     CRTStripHit.cxx
     CRTTrack.cxx
     CRTVeto.cxx
+    CRTBlob.cxx
     FEBData.cxx
     FEBTruthInfo.cxx
   LIBRARIES

--- a/sbnobj/SBND/CRT/CRTBlob.cxx
+++ b/sbnobj/SBND/CRT/CRTBlob.cxx
@@ -13,7 +13,7 @@ namespace sbnd {
       , fTs1        (0.)
       , fTs1Err     (0.)
       , fPE         (0.)
-      , fTaggerHits ({})
+      , fTaggerSPs  ({})
     {}
 
     CRTBlob::CRTBlob(const double &_ts0, const double &_ets0, const double &_ts1, const double &_ets1,
@@ -23,7 +23,7 @@ namespace sbnd {
       , fTs1        (_ts1)
       , fTs1Err     (_ets1)
       , fPE         (_pe)
-      , fTaggerHits (_tagger_hits)
+      , fTaggerSPs  (_tagger_hits)
     {}
 
     CRTBlob::~CRTBlob() {}
@@ -33,13 +33,13 @@ namespace sbnd {
     double                   CRTBlob::Ts1() const {return fTs1; }
     double                   CRTBlob::Ts1Err() const { return fTs1Err; }
     double                   CRTBlob::PE() const { return fPE; }
-    std::map<CRTTagger, int> CRTBlob::TaggerHits() const { return fTaggerHits; }
+    std::map<CRTTagger, int> CRTBlob::TaggerSPs() const { return fTaggerSPs; }
 
     int CRTBlob::TotalSpacePoints() const
     {
       int total = 0;
       
-      for(auto const& [ tagger, count ] : fTaggerHits)
+      for(auto const& [ tagger, count ] : fTaggerSPs)
         total += count;
 
       return total;
@@ -47,7 +47,7 @@ namespace sbnd {
 
     int CRTBlob::SpacePointsInTagger(const CRTTagger tagger) const
     {
-      return fTaggerHits.at(tagger);
+      return fTaggerSPs.at(tagger);
     }
   }
 }

--- a/sbnobj/SBND/CRT/CRTBlob.cxx
+++ b/sbnobj/SBND/CRT/CRTBlob.cxx
@@ -1,0 +1,55 @@
+#ifndef SBND_CRTBLOB_CXX
+#define SBND_CRTBLOB_CXX
+
+#include "sbnobj/SBND/CRT/CRTBlob.hh"
+
+namespace sbnd {
+
+  namespace crt {
+
+    CRTBlob::CRTBlob()
+      : fTs0        (0.)
+      , fTs0Err     (0.)
+      , fTs1        (0.)
+      , fTs1Err     (0.)
+      , fPE         (0.)
+      , fTaggerHits ({})
+    {}
+
+    CRTBlob::CRTBlob(const double &_ts0, const double &_ets0, const double &_ts1, const double &_ets1,
+                     const double &_pe, const std::map<CRTTagger, int> &_tagger_hits)
+      : fTs0        (_ts0)
+      , fTs0Err     (_ets0)
+      , fTs1        (_ts1)
+      , fTs1Err     (_ets1)
+      , fPE         (_pe)
+      , fTaggerHits (_tagger_hits)
+    {}
+
+    CRTBlob::~CRTBlob() {}
+
+    double                   CRTBlob::Ts0() const {return fTs0; }
+    double                   CRTBlob::Ts0Err() const { return fTs0Err; }
+    double                   CRTBlob::Ts1() const {return fTs1; }
+    double                   CRTBlob::Ts1Err() const { return fTs1Err; }
+    double                   CRTBlob::PE() const { return fPE; }
+    std::map<CRTTagger, int> CRTBlob::TaggerHits() const { return fTaggerHits; }
+
+    int CRTBlob::TotalSpacePoints() const
+    {
+      int total = 0;
+      
+      for(auto const& [ tagger, count ] : fTaggerHits)
+        total += count;
+
+      return total;
+    }
+
+    int CRTBlob::SpacePointsInTagger(const CRTTagger tagger) const
+    {
+      return fTaggerHits.at(tagger);
+    }
+  }
+}
+
+#endif

--- a/sbnobj/SBND/CRT/CRTBlob.cxx
+++ b/sbnobj/SBND/CRT/CRTBlob.cxx
@@ -2,17 +2,18 @@
 #define SBND_CRTBLOB_CXX
 
 #include "sbnobj/SBND/CRT/CRTBlob.hh"
+#include <limits>
 
 namespace sbnd {
 
   namespace crt {
 
     CRTBlob::CRTBlob()
-      : fTs0        (0.)
-      , fTs0Err     (0.)
-      , fTs1        (0.)
-      , fTs1Err     (0.)
-      , fPE         (0.)
+      : fTs0        (std::numeric_limits<double>::lowest())
+      , fTs0Err     (std::numeric_limits<double>::lowest())
+      , fTs1        (std::numeric_limits<double>::lowest())
+      , fTs1Err     (std::numeric_limits<double>::lowest())
+      , fPE         (std::numeric_limits<double>::lowest())
       , fTaggerSPs  ({})
     {}
 

--- a/sbnobj/SBND/CRT/CRTBlob.hh
+++ b/sbnobj/SBND/CRT/CRTBlob.hh
@@ -23,14 +23,14 @@ namespace sbnd::crt {
     double                   fTs1;        // average time according to T1 clock [ns]
     double                   fTs1Err;     // error on average time according to T1 clock [ns]
     double                   fPE;         // total PE
-    std::map<CRTTagger, int> fTaggerHits; // how many spacepoints from each tagger contribute to the blob
+    std::map<CRTTagger, int> fTaggerSPs;  // how many spacepoints from each tagger contribute to the blob
 
   public:
 
     CRTBlob();
 
     CRTBlob(const double &_ts0, const double &_ets0, const double &_ts1, const double &_ets1, const double &_pe,
-            const std::map<CRTTagger, int> &_tagger_hits);
+            const std::map<CRTTagger, int> &_tagger_sps);
 
     virtual ~CRTBlob();
 
@@ -39,7 +39,7 @@ namespace sbnd::crt {
     double                   Ts1() const;
     double                   Ts1Err() const;
     double                   PE() const;
-    std::map<CRTTagger, int> TaggerHits() const;
+    std::map<CRTTagger, int> TaggerSPs() const;
 
     int TotalSpacePoints() const;
     int SpacePointsInTagger(const CRTTagger tagger) const;

--- a/sbnobj/SBND/CRT/CRTBlob.hh
+++ b/sbnobj/SBND/CRT/CRTBlob.hh
@@ -1,0 +1,49 @@
+/**
+ * \class CRTBlob
+ *
+ * \brief Product to store a blob of CRT activity across all walls
+ *
+ * \author Henry Lay (h.lay@sheffield.ac.uk)
+ *
+ */
+
+#ifndef SBND_CRTBLOB_HH
+#define SBND_CRTBLOB_HH
+
+#include "sbnobj/SBND/CRT/CRTEnums.hh"
+
+#include <map>
+
+namespace sbnd::crt {
+
+  class CRTBlob {
+    
+    double                   fTs0;        // average time according to T0 clock [ns]
+    double                   fTs0Err;     // error on average time according to T0 clock [ns]
+    double                   fTs1;        // average time according to T1 clock [ns]
+    double                   fTs1Err;     // error on average time according to T1 clock [ns]
+    double                   fPE;         // total PE
+    std::map<CRTTagger, int> fTaggerHits; // how many spacepoints from each tagger contribute to the blob
+
+  public:
+
+    CRTBlob();
+
+    CRTBlob(const double &_ts0, const double &_ets0, const double &_ts1, const double &_ets1, const double &_pe,
+            const std::map<CRTTagger, int> &_tagger_hits);
+
+    virtual ~CRTBlob();
+
+    double                   Ts0() const;
+    double                   Ts0Err() const;
+    double                   Ts1() const;
+    double                   Ts1Err() const;
+    double                   PE() const;
+    std::map<CRTTagger, int> TaggerHits() const;
+
+    int TotalSpacePoints() const;
+    int SpacePointsInTagger(const CRTTagger tagger) const;
+  };
+}
+
+#endif

--- a/sbnobj/SBND/CRT/CRTCluster.cxx
+++ b/sbnobj/SBND/CRT/CRTCluster.cxx
@@ -3,15 +3,17 @@
 
 #include "sbnobj/SBND/CRT/CRTCluster.hh"
 
+#include <limits>
+
 namespace sbnd {
 
   namespace crt {
 
     CRTCluster::CRTCluster()
-      : fTs0          (0)
-      , fTs1          (0)
-      , fUnixS        (0)
-      , fNHits        (0)
+      : fTs0          (std::numeric_limits<double>::lowest())
+      , fTs1          (std::numeric_limits<double>::lowest())
+      , fUnixS        (std::numeric_limits<uint32_t>::max())
+      , fNHits        (std::numeric_limits<uint16_t>::max())
       , fTagger       (kUndefinedTagger)
       , fComposition  (kUndefinedSet)
     {}

--- a/sbnobj/SBND/CRT/CRTSpacePoint.cxx
+++ b/sbnobj/SBND/CRT/CRTSpacePoint.cxx
@@ -3,18 +3,20 @@
 
 #include "sbnobj/SBND/CRT/CRTSpacePoint.hh"
 
+#include <limits>
+
 namespace sbnd {
 
   namespace crt {
 
     CRTSpacePoint::CRTSpacePoint()
-      : fPos      ({0., 0., 0.})
-      , fPosErr   ({0., 0., 0.})
-      , fPE       (0.)
-      , fTs0      (0.)
-      , fTs0Err   (0.)
-      , fTs1      (0.)
-      , fTs1Err   (0.)
+      : fPos      ({std::numeric_limits<double>::lowest(), std::numeric_limits<double>::lowest(), std::numeric_limits<double>::lowest()})
+      , fPosErr   ({std::numeric_limits<double>::lowest(), std::numeric_limits<double>::lowest(), std::numeric_limits<double>::lowest()})
+      , fPE       (std::numeric_limits<double>::lowest())
+      , fTs0      (std::numeric_limits<double>::lowest())
+      , fTs0Err   (std::numeric_limits<double>::lowest())
+      , fTs1      (std::numeric_limits<double>::lowest())
+      , fTs1Err   (std::numeric_limits<double>::lowest())
       , fComplete (false)
     {}
 

--- a/sbnobj/SBND/CRT/CRTStripHit.cxx
+++ b/sbnobj/SBND/CRT/CRTStripHit.cxx
@@ -3,19 +3,21 @@
 
 #include "sbnobj/SBND/CRT/CRTStripHit.hh"
 
+#include <limits>
+
 namespace sbnd {
 
   namespace crt {
 
     CRTStripHit::CRTStripHit()
-      : fChannel      (0)
-      , fTs0          (0)
-      , fTs1          (0)
-      , fUnixS        (0)
-      , fPos          (0)
-      , fErr          (0)
-      , fADC1         (0)
-      , fADC2         (0)
+      : fChannel      (std::numeric_limits<uint32_t>::max())
+      , fTs0          (std::numeric_limits<double>::lowest())
+      , fTs1          (std::numeric_limits<double>::lowest())
+      , fUnixS        (std::numeric_limits<uint32_t>::max())
+      , fPos          (std::numeric_limits<double>::lowest())
+      , fErr          (std::numeric_limits<double>::lowest())
+      , fADC1         (std::numeric_limits<uint16_t>::max())
+      , fADC2         (std::numeric_limits<uint16_t>::max())
       , fSaturated1   (false)
       , fSaturated2   (false)
     {}

--- a/sbnobj/SBND/CRT/CRTTrack.cxx
+++ b/sbnobj/SBND/CRT/CRTTrack.cxx
@@ -3,18 +3,20 @@
 
 #include "sbnobj/SBND/CRT/CRTTrack.hh"
 
+#include <limits>
+
 namespace sbnd {
 
   namespace crt {
 
     CRTTrack::CRTTrack()
       : fPoints  ({})
-      , fTs0     (0.)
-      , fTs0Err  (0.)
-      , fTs1     (0.)
-      , fTs1Err  (0.)
-      , fPE      (0.)
-      , fToF     (0.)
+      , fTs0     (std::numeric_limits<double>::lowest())
+      , fTs0Err  (std::numeric_limits<double>::lowest())
+      , fTs1     (std::numeric_limits<double>::lowest())
+      , fTs1Err  (std::numeric_limits<double>::lowest())
+      , fPE      (std::numeric_limits<double>::lowest())
+      , fToF     (std::numeric_limits<double>::lowest())
       , fTaggers ({})
     {}
 

--- a/sbnobj/SBND/CRT/FEBData.cxx
+++ b/sbnobj/SBND/CRT/FEBData.cxx
@@ -5,17 +5,19 @@
 
 #include "sbnobj/SBND/CRT/FEBData.hh"
 
+#include <limits>
+
 namespace sbnd{
 namespace crt{
 
   FEBData::FEBData()
-  : fMac5(0)
-  , fFlags(0)
-  , fTs0(0)
-  , fTs1(0)
-  , fUnixS(0)
-  , fADC()
-  , fCoinc(0)
+  : fMac5(std::numeric_limits<uint16_t>::max())
+  , fFlags(std::numeric_limits<uint16_t>::max())
+  , fTs0(std::numeric_limits<uint32_t>::max())
+  , fTs1(std::numeric_limits<uint32_t>::max())
+  , fUnixS(std::numeric_limits<uint32_t>::max())
+  , fADC({})
+  , fCoinc(std::numeric_limits<uint32_t>::max())
   {}
 
   FEBData::FEBData(uint16_t mac5, uint16_t flags, uint32_t ts0, uint32_t ts1, uint32_t unixs, adc_array_t ADC, uint32_t coinc)

--- a/sbnobj/SBND/CRT/classes.h
+++ b/sbnobj/SBND/CRT/classes.h
@@ -9,6 +9,7 @@
 #include "sbnobj/SBND/CRT/CRTEnums.hh"
 #include "sbnobj/SBND/CRT/CRTTrack.hh"
 #include "sbnobj/SBND/CRT/CRTVeto.hh"
+#include "sbnobj/SBND/CRT/CRTBlob.hh"
 #include "sbnobj/Common/CRT/CRTHit.hh"
 #include "sbnobj/Common/CRT/CRTHit_Legacy.hh"
 #include "lardataobj/Simulation/AuxDetSimChannel.h"

--- a/sbnobj/SBND/CRT/classes_def.xml
+++ b/sbnobj/SBND/CRT/classes_def.xml
@@ -101,6 +101,7 @@
   <enum name="sbnd::crt::CRTTagger" ClassVersion="10"/>
   <class name="std::set<sbnd::crt::CRTTagger>"/>
   <class name="std::vector<sbnd::crt::CRTTagger>"/>
+  <class name="std::map<sbnd::crt::CRTTagger, int>"/>
   <enum name="sbnd::crt::CoordSet" ClassVersion="10"/>
   <enum name="sbnd::crt::CRTChannelStatus" ClassVersion="10"/>
 
@@ -181,5 +182,21 @@
   <class name="art::Wrapper< art::Assns<sbnd::crt::CRTVeto, sbnd::crt::CRTSpacePoint, void> >"           />
   <class name="art::Assns<sbnd::crt::CRTSpacePoint, sbnd::crt::CRTVeto,    void>"           />
   <class name="art::Wrapper< art::Assns<sbnd::crt::CRTSpacePoint, sbnd::crt::CRTVeto, void> >"           />
+
+  <!-- CRTBlob -->
+
+  <class name="sbnd::crt::CRTBlob" ClassVersion="10">
+    <version ClassVersion="10" checksum="2014295208"/>
+  </class>
+  <class name="std::vector<sbnd::crt::CRTBlob>"/>
+  <class name="art::Wrapper<sbnd::crt::CRTBlob>"/>
+  <class name="art::Wrapper<std::vector<sbnd::crt::CRTBlob> >"/>
+
+  <!-- associations  -->
+
+  <class name="art::Assns<sbnd::crt::CRTSpacePoint, sbnd::crt::CRTBlob,    void>"           />
+  <class name="art::Wrapper< art::Assns<sbnd::crt::CRTSpacePoint, sbnd::crt::CRTBlob, void> >"           />
+  <class name="art::Assns<sbnd::crt::CRTBlob, sbnd::crt::CRTSpacePoint,    void>"           />
+  <class name="art::Wrapper< art::Assns<sbnd::crt::CRTBlob, sbnd::crt::CRTSpacePoint, void> >"           />
 
 </lcgdict>

--- a/sbnobj/SBND/CRT/classes_def.xml
+++ b/sbnobj/SBND/CRT/classes_def.xml
@@ -186,7 +186,7 @@
   <!-- CRTBlob -->
 
   <class name="sbnd::crt::CRTBlob" ClassVersion="10">
-    <version ClassVersion="10" checksum="2014295208"/>
+    <version ClassVersion="10" checksum="3696724874"/>
   </class>
   <class name="std::vector<sbnd::crt::CRTBlob>"/>
   <class name="art::Wrapper<sbnd::crt::CRTBlob>"/>


### PR DESCRIPTION
I am starting to put together slides and PRs to preserve work of mine that lives offline before I leave.

The CRTBlob reconstruction aims to produce objects that represent the totality of all activity happening within a fcl-configurable coincidence window.  They are similar to CRTTracks but without geometric track constraints, and as such can capture all activity from a single source, for example when multiple particles from the same air shower are detected or secondary particles are produced from the muon scattering.

It was used to produce a plot for the detector paper and is therefore worth preserving. It is not run by default in production fcls but does provide fcls for running it independently in the CRT-only workflow or standalone. Nothing prevents it being added to production fcls in future if it is desired for any analyses.

It is documented in slides: https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=45658
Accompanying PR: https://github.com/SBNSoftware/sbndcode/pull/916