### PR TITLE
CRT Strip Hit Saturation

### DIFF
--- a/sbnobj/SBND/CRT/CRTStripHit.cxx
+++ b/sbnobj/SBND/CRT/CRTStripHit.cxx
@@ -21,7 +21,7 @@ namespace sbnd {
     {}
 
     CRTStripHit::CRTStripHit(uint32_t _channel, double _ts0, double _ts1, uint32_t _s, double _pos,
-                             double _err, uint16_t _adc1, uint16_t _adc2)
+                             double _err, uint16_t _adc1, uint16_t _adc2, uint16_t _saturation_level)
       : fChannel      (_channel)
       , fTs0          (_ts0)
       , fTs1          (_ts1)
@@ -31,8 +31,8 @@ namespace sbnd {
       , fADC1         (_adc1)
       , fADC2         (_adc2)
     {
-      fSaturated1 = fADC1 == 4095;
-      fSaturated2 = fADC2 == 4095;
+      fSaturated1 = fADC1 == _saturation_level;
+      fSaturated2 = fADC2 == _saturation_level;
     }
 
     CRTStripHit::CRTStripHit(uint32_t _channel, double _ts0, double _ts1, uint32_t _s, double _pos,

--- a/sbnobj/SBND/CRT/CRTStripHit.cxx
+++ b/sbnobj/SBND/CRT/CRTStripHit.cxx
@@ -31,8 +31,8 @@ namespace sbnd {
       , fADC1         (_adc1)
       , fADC2         (_adc2)
     {
-      fSaturated1 = fADC1 == _saturation_level;
-      fSaturated2 = fADC2 == _saturation_level;
+      fSaturated1 = fADC1 >= _saturation_level;
+      fSaturated2 = fADC2 >= _saturation_level;
     }
 
     CRTStripHit::CRTStripHit(uint32_t _channel, double _ts0, double _ts1, uint32_t _s, double _pos,

--- a/sbnobj/SBND/CRT/CRTStripHit.hh
+++ b/sbnobj/SBND/CRT/CRTStripHit.hh
@@ -32,7 +32,7 @@ namespace sbnd::crt {
     CRTStripHit();
     
     CRTStripHit(uint32_t _channel, double _ts0, double _ts1, uint32_t _s, double _pos,
-                double _err, uint16_t _adc1, uint16_t _adc2);
+                double _err, uint16_t _adc1, uint16_t _adc2, uint16_t _saturation_level);
 
     CRTStripHit(uint32_t _channel, double _ts0, double _ts1, uint32_t _s, double _pos,
                 double _err, uint16_t _adc1, uint16_t _adc2, bool _saturated1, bool _saturated2);


### PR DESCRIPTION
I am starting to put together slides and PRs to preserve work of mine that lives offline before I leave.

The saturation parameters in the CRTStripHit object were being filled via a hardcoded value in the constructor. This PR ensures they can be controlled a little more subtly by passing that value in the constructor fields. This constructor will not be directly used as the accompanying PR makes use of the other constructor (fully explicit) but this is still worth changing to remove the hardcoded element.

It is documented in slides: https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=45697
Accompanying PR: https://github.com/SBNSoftware/sbndcode/pull/917