### PR TITLE
Added new blip energy records

### DIFF
--- a/sbnobj/SBND/Blip/BlipDataTypes.h
+++ b/sbnobj/SBND/Blip/BlipDataTypes.h
@@ -192,9 +192,13 @@ namespace blip {
      */
     float     Time            = -999;
     float     Charge          = -9;         ///< Charge on calorimetry plane [e-]
-    float     Energy          = -999;       ///< Reconstructed energy in the calorimetry plane (const dE/dx, fcl-configurable) [MeV]
-    float     EnergyESTAR     = -999;       ///< Reconstructed energy in the calorimetry plane (ESTAR method from ArgoNeuT)    [MeV]
-    float     EnergyPSTAR     = -999;       ///< Reconstructed energy in the calorimetry plane (PSTAR method similar with ESTAR method from ArgoNeuT) [MeV]
+
+    float     Energy          = -999;       ///< Reconstructed energy in the calorimetry plane (const dE/dx, fcl-configurable) Drift corrected to event t0 [MeV]
+    float     EnergyESTAR     = -999;       ///< Reconstructed energy in the calorimetry plane (ESTAR method from ArgoNeuT)  Drift corrected to event t0  [MeV]
+    float     EnergyPSTAR     = -999;       ///< Reconstructed energy in the calorimetry plane (PSTAR method similar with ESTAR method from ArgoNeuT)  Drift corrected to event t0 [MeV]
+    float     EnergyNoDriftCorrection          = -999;       ///< Reconstructed energy in the calorimetry plane (const dE/dx, fcl-configurable) [MeV]
+    float     EnergyESTARNoDriftCorrection     = -999;       ///< Reconstructed energy in the calorimetry plane (ESTAR method from ArgoNeuT)    [MeV]
+    float     EnergyPSTARNoDriftCorrection     = -999;       ///< Reconstructed energy in the calorimetry plane (PSTAR method similar with ESTAR method from ArgoNeuT) [MeV]
     float     ProxTrkDist     = -9;         ///< 3-D distance to closest track, assuming the blip was concident with event trigger [cm]
     /**
      * @brief 3-D distance to closest track, assuming the blip was coincident with event trigger [cm]

--- a/sbnobj/SBND/Blip/classes_def.xml
+++ b/sbnobj/SBND/Blip/classes_def.xml
@@ -1,6 +1,7 @@
 <lcgdict>
 <class name="art::Wrapper<std::vector<blip::Blip> >"/>
-<class name="blip::Blip" ClassVersion="10" >
+<class name="blip::Blip" ClassVersion="11" >
+ <version ClassVersion="11" checksum="3855960958"/>
  <version ClassVersion="10" checksum="2428317905"/>
 </class>
 <class name="std::vector<blip::Blip>"/>


### PR DESCRIPTION
Adding additional blip energy variables so analyzers have access to a drift corrected energy, as well as an explicitly not drift corrected one.

All drift corrections are anchored to the event timestamp, so the beam blips will come out with the right energy. Any out-of-time blip activity will be mis-corrected, so the noDriftCorrection variables are saved as new variables.

