### PR TITLE
Modify corrected OpFlash to include particle and photon propagation time

### DIFF
--- a/sbnobj/Common/Reco/CorrectedOpFlashTiming.h
+++ b/sbnobj/Common/Reco/CorrectedOpFlashTiming.h
@@ -27,6 +27,8 @@ namespace sbn {
   float        NuToFLight             { fDefault };      ///< | Nu ToF using light only | (us)
   float        NuToFCharge             { fDefault };       ///< | Nu ToF Z from tpc vertex | (us)
   float        OpFlashT0Corrected    { fDefault };       ///< | OpFlash Time wrt RWM time after light propagation corrections | (us)
+  float        ParticlePropagationTime { fDefault }; ///< | Average particle propagation time used to correct flash t0 | (us)
+  float        PhotonPropagationTime { fDefault }; ///< | Average photon propagation time used to correct flash t0 | (us)
   /// @}
   
   };

--- a/sbnobj/Common/Reco/classes_def.xml
+++ b/sbnobj/Common/Reco/classes_def.xml
@@ -315,7 +315,9 @@
 
   <class name="std::vector<geo::PlaneID>"/>
 
-  <class name="sbn::CorrectedOpFlashTiming" ClassVersion="16">
+  <class name="sbn::CorrectedOpFlashTiming" ClassVersion="18">
+   <version ClassVersion="18" checksum="1139303800"/>
+   <version ClassVersion="17" checksum="1139303800"/>
    <version ClassVersion="16" checksum="1734226620"/>
    <version ClassVersion="15" checksum="2401924061"/>
    <version ClassVersion="14" checksum="2635318722"/>


### PR DESCRIPTION
This PR modifies the CorrectedOpFlashTiming object to include the photon time of flight and particle propagation time used during the correction of the op flash timing. These attributes are required for downstream correction. More information can be found [here](https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=47101).

This PR should we merged with 
https://github.com/SBNSoftware/sbndcode/pull/946.
https://github.com/SBNSoftware/sbnanaobj/pull/195
https://github.com/SBNSoftware/sbncode/pull/666